### PR TITLE
Fix NXP sample cmake

### DIFF
--- a/.github/scripts/ci_tests.sh
+++ b/.github/scripts/ci_tests.sh
@@ -61,6 +61,5 @@ exit_if_binary_does_not_exist "build_st_b-l4s5i-iot01a" "iot-middleware-sample-p
 
 echo -e "::group::Building sample for NXP mimxrt1060 port"
 sample_build "NXP" "mimxrt1060" "build_nxp_mimxrt1060"
-# TODO: GH Issue 66
-# exit_if_binary_does_not_exist "build_nxp_mimxrt1060" "iot-middleware-sample.elf"
+exit_if_binary_does_not_exist "build_nxp_mimxrt1060" "iot-middleware-sample.elf"
 exit_if_binary_does_not_exist "build_nxp_mimxrt1060" "iot-middleware-sample-pnp.elf"

--- a/demos/projects/NXP/mimxrt1060/CMakeLists.txt
+++ b/demos/projects/NXP/mimxrt1060/CMakeLists.txt
@@ -1,36 +1,46 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
-set(MCUX_SDK_PROJECT_NAME ${PROJECT_NAME}-pnp)
+# set parent scope path
+set(BOARD_DEMO_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/config CACHE INTERNAL "Config path")
+set(BOARD_DEMO_FREERTOS_PORT_PATH ${FreeRTOS_ARM_CM4F_PATH} CACHE INTERNAL "FreeRTOS Port used ")
+
+# Define
+add_definitions(-DFSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE=1 -DSDK_DEBUGCONSOLE=1 -DSDK_DEBUGCONSOLE_UART -DLWIP_DHCP=1 -DLWIP_DNS=1 -DUSE_RTOS=1 -DFSL_RTOS_FREE_RTOS -DLWIP_TIMEVAL_PRIVATE=0 -D__STARTUP_CLEAR_BSS -D__STARTUP_INITIALIZE_NONCACHEDATA)
+include(${CMAKE_CURRENT_SOURCE_DIR}/gcc_flags.cmake)
+
+set(MCUX_SDK_PROJECT_NAME mcux-sdk-lib)
+
+add_library(${MCUX_SDK_PROJECT_NAME})
+target_include_directories(${MCUX_SDK_PROJECT_NAME}
+  PUBLIC
+    ${BOARD_DEMO_FREERTOS_PORT_PATH}
+)
+target_link_libraries(${MCUX_SDK_PROJECT_NAME}
+  PUBLIC
+    FreeRTOS
+)
 
 nxp_mcux_sdk_fetch()
 lwip_fetch()
 
 list(APPEND CMAKE_MODULE_PATH ${NXP_MCUX_SDK_PATH})
 
-# set parent scope path
-set(BOARD_DEMO_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/config CACHE INTERNAL "Config path")
-set(BOARD_DEMO_FREERTOS_PORT_PATH ${FreeRTOS_ARM_CM4F_PATH} CACHE INTERNAL "FreeRTOS Port used ")
-
 find_package(LWIP)
-
-include(${CMAKE_CURRENT_SOURCE_DIR}/gcc_flags.cmake)
 
 include_directories(${BOARD_DEMO_CONFIG_PATH})
 include_directories(nxp_code)
 include_directories(nxp_code/lwip)
 
 file(GLOB NXPCODE_SOURCES nxp_code/*.c nxp_code/lwip/*.c)
-set(PROJECT_SOURCES ${NXPCODE_SOURCES} main.c)
-
-add_executable(${PROJECT_NAME}-pnp ${PROJECT_SOURCES})
+set(PROJECT_SOURCES ${NXPCODE_SOURCES}
+    ${NXP_MCUX_SDK_PATH}/devices/MIMXRT1062/xip/fsl_flexspi_nor_boot.c
+    ${NXP_MCUX_SDK_PATH}/boards/evkmimxrt1060/xip/evkmimxrt1060_flexspi_nor_config.c
+    main.c)
 
 # configure modules
 set(CONFIG_USE_driver_lpuart true)
 set(MCUX_DEVICE "MIMXRT1062")
-
-# Define
-add_definitions(-DFSL_FEATURE_PHYKSZ8081_USE_RMII50M_MODE=1 -DSDK_DEBUGCONSOLE=1 -DSDK_DEBUGCONSOLE_UART -DLWIP_DHCP=1 -DLWIP_DNS=1 -DUSE_RTOS=1 -DFSL_RTOS_FREE_RTOS -DLWIP_TIMEVAL_PRIVATE=0 -D__STARTUP_CLEAR_BSS -D__STARTUP_INITIALIZE_NONCACHEDATA)
 
 # Include sdk
 include(all_devices)
@@ -66,7 +76,7 @@ include(driver_iomuxc)
 
 include(utility_assert)
 
-include(driver_xip_device)
+#include(driver_xip_device)
 
 include(driver_xip_board)
 
@@ -90,6 +100,33 @@ include(driver_phy-common)
 
 include(driver_dcp)
 
+add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    FreeRTOS::Timers
+    FreeRTOS::Heap::5
+    FreeRTOS::ARM_CM4F
+    FreeRTOS::EventGroups
+    FreeRTOSPlus::Utilities::backoff_algorithm
+    FreeRTOSPlus::Utilities::logging
+    FreeRTOSPlus::ThirdParty::mbedtls
+    az::iot_middleware::freertos
+    LWIP
+    SAMPLE::SOCKET::LWIP
+    SAMPLE::AZUREIOT
+    SAMPLE::TRANSPORT::MBEDTLS
+    ${MCUX_SDK_PROJECT_NAME}
+    )
+
+add_map_file(${PROJECT_NAME} ${PROJECT_NAME}.map)
+
+add_custom_command(TARGET ${PROJECT_NAME}
+    # Run after all other rules within the target have been executed
+    POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -Obinary $<TARGET_FILE:${PROJECT_NAME}> ${PROJECT_NAME}.bin
+    COMMENT "Generate Bin file"
+    VERBATIM)
+
+add_executable(${PROJECT_NAME}-pnp ${PROJECT_SOURCES})
 target_link_libraries(${PROJECT_NAME}-pnp PRIVATE
     FreeRTOS::Timers
     FreeRTOS::Heap::5
@@ -102,7 +139,9 @@ target_link_libraries(${PROJECT_NAME}-pnp PRIVATE
     LWIP
     SAMPLE::SOCKET::LWIP
     SAMPLE::AZUREIOTPNP
-    SAMPLE::TRANSPORT::MBEDTLS)
+    SAMPLE::TRANSPORT::MBEDTLS
+    ${MCUX_SDK_PROJECT_NAME}
+    )
 
 add_map_file(${PROJECT_NAME}-pnp ${PROJECT_NAME}-pnp.map)
 

--- a/demos/projects/NXP/mimxrt1060/MIMXRT1062xxxxx_sdram.ld
+++ b/demos/projects/NXP/mimxrt1060/MIMXRT1062xxxxx_sdram.ld
@@ -28,7 +28,7 @@
 /* Entry Point */
 ENTRY(Reset_Handler)
 
-HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
+HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0800;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x00000400 : 0;
 NCACHE_HEAP_START = DEFINED(__heap_noncacheable__) ? 0x82000000 - HEAP_SIZE : 0x81E00000 - HEAP_SIZE;


### PR DESCRIPTION
When using NXP SDK as static library, sample binaries failed to
flash to board. This was happening because boot headers were missing
from final sample binary. Drop to these boot headers is done by linker when
boot headers are part of static library. Following stack overflow
describes the problem:
https://stackoverflow.com/questions/44675582/gcc-how-to-tell-linker-not-to-skip-unused-sections

As part of this fix adding boot header object files to linking step.

