### PR TITLE
[NXP] Use --whole-archive gcc flag

### DIFF
--- a/demos/projects/NXP/mimxrt1060/CMakeLists.txt
+++ b/demos/projects/NXP/mimxrt1060/CMakeLists.txt
@@ -33,10 +33,7 @@ include_directories(nxp_code)
 include_directories(nxp_code/lwip)
 
 file(GLOB NXPCODE_SOURCES nxp_code/*.c nxp_code/lwip/*.c)
-set(PROJECT_SOURCES ${NXPCODE_SOURCES}
-    ${NXP_MCUX_SDK_PATH}/devices/MIMXRT1062/xip/fsl_flexspi_nor_boot.c
-    ${NXP_MCUX_SDK_PATH}/boards/evkmimxrt1060/xip/evkmimxrt1060_flexspi_nor_config.c
-    main.c)
+set(PROJECT_SOURCES ${NXPCODE_SOURCES} main.c)
 
 # configure modules
 set(CONFIG_USE_driver_lpuart true)
@@ -76,7 +73,7 @@ include(driver_iomuxc)
 
 include(utility_assert)
 
-#include(driver_xip_device)
+include(driver_xip_device)
 
 include(driver_xip_board)
 

--- a/demos/projects/NXP/mimxrt1060/gcc_flags.cmake
+++ b/demos/projects/NXP/mimxrt1060/gcc_flags.cmake
@@ -45,6 +45,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} " \
     -Xlinker --gc-sections \ 
     -Xlinker -static \ 
     -Xlinker -z -Xlinker muldefs \
+    -Xlinker --whole-archive \
     -T${CMAKE_CURRENT_SOURCE_DIR}/MIMXRT1062xxxxx_sdram.ld")
 
 function(add_map_file TARGET_NAME MAP_FILE_NAME)


### PR DESCRIPTION
Adding --whole-archive in nxp build, based on feedback
received from nxp: https://github.com/NXPmicro/mcux-sdk/issues/29
