### PR TITLE
Remove trailing space from true string which was breaking the setLedState command

### DIFF
--- a/demos/sample_azure_iot_gsg/sample_azure_iot_gsg.c
+++ b/demos/sample_azure_iot_gsg/sample_azure_iot_gsg.c
@@ -118,7 +118,7 @@
 #define sampleazureiotgsgTOTAL_STORAGE_PROPERTY_NAME             ( "totalStorage" )
 #define sampleazureiotgsgTOTAL_MEMORY_PROPERTY_NAME              ( "totalMemory" )
 
-#define sampleazureiotgsgTRUE                                    ( "true " )
+#define sampleazureiotgsgTRUE                                    ( "true" )
 /*-----------------------------------------------------------*/
 
 /* Each compilation unit must define the NetworkContext struct. */


### PR DESCRIPTION
## Purpose
the SetLedState command was failing as the bool argument matching was broken

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Run the STML475 GSG
* Trigger a SetLedState true command
* Confirm the LED turns on

## What to Check
Verify that the following are valid
* The LED turns on and off when the SetLedState command is used.