### PR TITLE
Add size chart and improve ESP-IDF instructions in ESP32 samples readme

### DIFF
--- a/demos/projects/ESPRESSIF/aziotkit/README.md
+++ b/demos/projects/ESPRESSIF/aziotkit/README.md
@@ -310,11 +310,11 @@ I (6322) tls_freertos: (Network connection 0x3ffc8c4c) Connection to contoso-iot
 The following chart shows the RAM and ROM usage for the ESPRESSIF ESP32 Azure IoT Kit.
 Build options: Compile optimized for size (-Os) and no logging (-DLIBRARY_LOG_LEVEL=LOG_NONE).
 This sample can include either IoT Hub only or both IoT Hub and DPS services. Also it uses IoT Plug-and-Play. The table below shows RAM/ROM sizes considering:
--  Middleware libraries only – represents the libraries for Azure IoT connection.
+-  Middleware libraries only – represents the libraries for Azure IoT connection and features.
 -  Total size – which includes the Azure IoT middleware for FreeRTOS, Mbed TLS, FreeRTOS, CoreMQTT and the HAL for the dev kit.
 
 |  | Middleware library size | | Total Size | |
 |---------|----------|---------|---------|---------
-|**Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
+| **Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
 | IoT Hub + DPS | 37.74 KB | 12 bytes | 704.66 KB | 124.27 KB
 | IoT Hub only | 28.34 KB | 12 bytes | 694.43 | 122.92 KB

--- a/demos/projects/ESPRESSIF/aziotkit/README.md
+++ b/demos/projects/ESPRESSIF/aziotkit/README.md
@@ -27,7 +27,9 @@
 
 2. ESP-IDF
 
-    For Windows users, if you don't have [Espressif ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) installed yet, use [Espressif official installer](https://dl.espressif.com/dl/esp-idf/?idf=4.4), for other Operating Systems or to update an existing installation, follow [Espressif official documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#get-started).
+    On Windows, install the ESPRESSIF ESP-IDF using this [download link](https://dl.espressif.com/dl/esp-idf/?idf=4.4).
+
+    For other Operating Systems or to update an existing installation, follow [Espressif official documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#get-started).
 
 3. Azure IoT Embedded middleware for FreeRTOS
 
@@ -303,3 +305,16 @@ I (6322) tls_freertos: (Network connection 0x3ffc8c4c) Connection to contoso-iot
 ...
 ```
 </details>
+
+## Size Chart
+The following chart shows the RAM and ROM usage for the ESPRESSIF ESP32 Azure IoT Kit.
+Build options: Compile optimized for size (-Os) and no logging (-DLIBRARY_LOG_LEVEL=LOG_NONE).
+This sample can include either IoT Hub only or both IoT Hub and DPS services. Also it uses IoT Plug-and-Play. The table below shows RAM/ROM sizes considering:
+-  Middleware libraries only – represents the libraries for Azure IoT connection.
+-  Total size – which includes the Azure IoT middleware for FreeRTOS, Mbed TLS, FreeRTOS, CoreMQTT and the HAL for the dev kit.
+
+|  | Middleware library size | | Total Size | |
+|---------|----------|---------|---------|---------
+|**Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
+| IoT Hub + DPS | 37.74 KB | 12 bytes | 704.66 KB | 124.27 KB
+| IoT Hub only | 28.34 KB | 12 bytes | 694.43 | 122.92 KB

--- a/demos/projects/ESPRESSIF/esp32/README.md
+++ b/demos/projects/ESPRESSIF/esp32/README.md
@@ -27,7 +27,9 @@
 
 2. ESP-IDF
 
-    For Windows users, if you don't have [Espressif ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) installed yet, use [Espressif official installer](https://dl.espressif.com/dl/esp-idf/?idf=4.4), for other Operating Systems or to update an existing installation, follow [Espressif official documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#get-started).
+    On Windows, install the ESPRESSIF ESP-IDF using this [download link](https://dl.espressif.com/dl/esp-idf/?idf=4.4).
+
+    For other Operating Systems or to update an existing installation, follow [Espressif official documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#get-started).
 
 3. Azure IoT Embedded middleware for FreeRTOS
 
@@ -303,3 +305,18 @@ I (6322) tls_freertos: (Network connection 0x3ffc8c4c) Connection to contoso-iot
 ...
 ```
 </details>
+
+## Size Chart
+The following chart shows the RAM and ROM usage for the ESPRESSIF ESP32 microcontroller.
+Build options: Compile optimized for size (-Os) and no logging (-DLIBRARY_LOG_LEVEL=LOG_NONE).
+This sample can include either IoT Hub only or both IoT Hub and DPS services. Also it can optionaly use IoT Plug-and-Play. The table below shows RAM/ROM sizes considering:
+-  Middleware libraries only – represents the libraries for Azure IoT connection.
+-  Total size – which includes the Azure IoT middleware for FreeRTOS, Mbed TLS, FreeRTOS, CoreMQTT and the HAL for the dev kit.
+
+|  | Middleware library size | | Total Size | |
+|---------|----------|---------|---------|---------
+|**Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
+| IoT Hub + DPS + PnP | 38.13 KB | 12 bytes | 704.81 KB | 119.69 KB
+| IoT Hub + DPS | 38.13 KB | 12 bytes | 704.81 KB | 119.69 KB
+| IoT Hub + PnP | 28.74 KB | 12 bytes | 694.81 KB | 118.34 KB
+| IoT Hub only | 28.73 KB | 12 bytes | 694.65 KB | 118.34 KB

--- a/demos/projects/ESPRESSIF/esp32/README.md
+++ b/demos/projects/ESPRESSIF/esp32/README.md
@@ -309,13 +309,13 @@ I (6322) tls_freertos: (Network connection 0x3ffc8c4c) Connection to contoso-iot
 ## Size Chart
 The following chart shows the RAM and ROM usage for the ESPRESSIF ESP32 microcontroller.
 Build options: Compile optimized for size (-Os) and no logging (-DLIBRARY_LOG_LEVEL=LOG_NONE).
-This sample can include either IoT Hub only or both IoT Hub and DPS services. Also it can optionaly use IoT Plug-and-Play. The table below shows RAM/ROM sizes considering:
--  Middleware libraries only – represents the libraries for Azure IoT connection.
+This sample can include either IoT Hub only or both IoT Hub and DPS services. Also it can optionally use IoT Plug-and-Play. The table below shows RAM/ROM sizes considering:
+-  Middleware libraries only – represents the libraries for Azure IoT connection and features.
 -  Total size – which includes the Azure IoT middleware for FreeRTOS, Mbed TLS, FreeRTOS, CoreMQTT and the HAL for the dev kit.
 
 |  | Middleware library size | | Total Size | |
 |---------|----------|---------|---------|---------
-|**Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
+| **Sample** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** | **Flash (code,rodata)** | **DRAM,IRAM (bss,data)** |
 | IoT Hub + DPS + PnP | 38.13 KB | 12 bytes | 704.81 KB | 119.69 KB
 | IoT Hub + DPS | 38.13 KB | 12 bytes | 704.81 KB | 119.69 KB
 | IoT Hub + PnP | 28.74 KB | 12 bytes | 694.81 KB | 118.34 KB


### PR DESCRIPTION
## Purpose

All changes pertain to the readme.md of the esp32 and esp32-aziotkit samples.
- Clarifying steps of how to install the ESP-IDF;
- Add size chart for both samples.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```
