### PR TITLE
Switching VSCode experience to the default powershell 5.1 in Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,7 +21,7 @@
             "type": "shell",
             "isBackground": false,
             "windows" : {
-                "command": "pwsh .github/scripts/fetch_freertos.ps1 libs/FreeRTOS",
+                "command": "powershell .github/scripts/fetch_freertos.ps1 libs/FreeRTOS",
             },
             "linux" : {
                 "command": ".github/scripts/fetch_freertos.sh libs/FreeRTOS"


### PR DESCRIPTION
The change is scoped to Windows builds only: use Powershell instead of PWSH which is not installed by default (see https://aka.ms/PSWindows for details).
