### PR TITLE
Adding workaround for long path issues

### DIFF
--- a/demos/projects/ESPRESSIF/aziotkit/GSG.md
+++ b/demos/projects/ESPRESSIF/aziotkit/GSG.md
@@ -33,7 +33,7 @@ You will complete the following tasks:
 
     > * ESPRESSIF [ESP32-Azure IoT Kit](https://www.espressif.com/products/devkits/esp32-azure-kit/overview)
     > * Wi-Fi 2.4 GHz
-    > * USB 2.0 A male to Micro USB male cable
+    > * USB 2.0 A male to Micro USB male data cable
 
 ## Prepare the development environment
 
@@ -178,7 +178,7 @@ Save configuration:
 In your console, run the following commands from the *iot-middleware-freertos-samples\demos\projects\ESPRESSIF\aziotkit* directory to build the device image:
 
 ```shell
-idf.py --no-ccache build
+idf.py --no-ccache -B "C:\espbuild" build
 ```
 
 After the build completes, you can confirm that the binary file was created with the following path:
@@ -200,10 +200,10 @@ After the build completes, you can confirm that the binary file was created with
 1. From the ESP-IDF Powershell, execute the following command, substituting the correct COM Port from the previous step  (e.g. **COM3**):
 
     ```shell
-    idf.py -p <COM Port> flash
+    idf.py --no-ccache -B "C:\espbuild" -p <COM port> flash
     
     ```
-    **Important**: You might get an error after executing the command above ("No such file or directory"). This is a known ESP-IDF error, and the workaround is documented [here](https://github.com/Azure-Samples/iot-middleware-freertos-samples/issues/124)
+    The path `"C:\espbuild"` above is only a suggestion, feel free to use a different one, as long as it is near your root directory, for a shorter path.
 
 1. Check the output completes with the following text for a successful flash:
 
@@ -222,7 +222,7 @@ You can use the ESP-IDF monitor tool to observe communication and confirm that y
 1. From the ESP-IDF Powershell, start the monitoring tool, substituting the correct COM Port:
 
     ```shell
-    idf.py -p <COM Port> monitor
+    idf.py -B "C:\espbuild" -p <COM port> monitorr
     ```
 
 1. Check for the following output to confirm that the device is initialized and connected to Azure IoT.

--- a/demos/projects/ESPRESSIF/aziotkit/README.md
+++ b/demos/projects/ESPRESSIF/aziotkit/README.md
@@ -163,7 +163,7 @@ idf.py --no-ccache -B "C:\espbuild" build
     On **Linux**:
 
     ```shell
-    idf.py --no-ccache -B "C:\espbuild" -p /dev/ttyUSB0 flash
+    idf.py -p /dev/ttyUSB0 flash
     ```
     </details>
 
@@ -183,7 +183,7 @@ The output should show traces similar to:
 <summary>See more...</summary>
 
 ```shell
-$ idf.py -B "C:\espbuild" -p /dev/ttyUSB0 monitor
+$ idf.py -p /dev/ttyUSB0 monitor
 Executing action: monitor
 Running idf_monitor in directory /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32
 Executing "/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python /esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix xtensa-esp32-elf- --target esp32 --revision 0 /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32/build/azure_iot_freertos_esp32.elf -m '/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python' '/esp/esp-idf/tools/idf.py' '-p' '/dev/ttyUSB0'"...

--- a/demos/projects/ESPRESSIF/aziotkit/README.md
+++ b/demos/projects/ESPRESSIF/aziotkit/README.md
@@ -4,7 +4,8 @@
 
 - [ESPRESSIF ESP32 Azure IoT Kit Board](https://www.espressif.com/en/news/Microsoft_Plug-and-Play_with_ESP32-Azure_IoT_Kit)
 - Micro USB 2.0 male cable
-- WiFi Connection
+- Wi-Fi 2.4 GHz
+- USB 2.0 A male to Micro USB male data cable
 - [ESP-IDF](https://idf.espressif.com/) (Version 4.3 for Microsoft Windows or 4.4 for Linux)
 - To run this sample you can use a device previously created in your IoT Hub or have the Azure IoT Middleware for FreeRTOS provision your device automatically using DPS.
 
@@ -57,10 +58,9 @@ To connect the ESPRESSIF ESP32 to Azure, you will update the sample configuratio
 
 The configuration of the ESPRESSIF ESP32 sample uses ESP-IDF' samples standard [kconfig](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html) configuration.
 
-On a [console with ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-4-set-up-the-environment-variables), run the following commands:
+On a [console with ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-4-set-up-the-environment-variables), navigate to the ESP-Azure IoT Kit project directory: `demos\projects\ESPRESSIF\aziotkit` and run the following commands:
 
 ```shell
-cd demos\projects\ESPRESSIF\aziotkit
 idf.py menuconfig
 ```
 
@@ -99,11 +99,10 @@ After that, close the configuration utility (`Shift + Q`).
 
 > This step assumes you are in the ESPRESSIF ESP32 sample directory (same as configuration step above).
 
-> On Windows, errors might still occur if a path is too long. Espressif recommends setting the following environment variable on ESP-IDF console `IDF_CCACHE_ENABLE=0` as a workaround.
-To build the device image, run the following command:
+To build the device image, run the following command (the path `"C:\espbuild"` is only a suggestion, feel free to use a different one, as long as it is near your root directory, for a shorter path):
 
 ```bash
-idf.py build
+idf.py --no-ccache -B "C:\espbuild" build
 ```
 
 ## Flash the image
@@ -149,7 +148,7 @@ idf.py build
     > This step assumes you are in the ESPRESSIF ESP32 sample directory (same as configuration step above).
 
     ```bash
-    idf.py -p <COM port> flash
+    idf.py --no-ccache -B "C:\espbuild" -p <COM port> flash    
     ```
 
     <details>
@@ -158,13 +157,13 @@ idf.py build
     On **Windows**:
 
     ```shell
-    idf.py -p COM5 flash
+    idf.py --no-ccache -B "C:\espbuild" -p COM5 flash
     ```
 
     On **Linux**:
 
     ```shell
-    idf.py -p /dev/ttyUSB0 flash
+    idf.py --no-ccache -B "C:\espbuild" -p /dev/ttyUSB0 flash
     ```
     </details>
 
@@ -175,7 +174,7 @@ You can use any terminal application to monitor the operation of the device and 
 Alternatively you can use ESP-IDF monitor:
 
 ```bash
-idf.py -p <COM port> monitor
+idf.py -B "C:\espbuild" -p <COM port> monitor 
 ```
 
 The output should show traces similar to:
@@ -184,7 +183,7 @@ The output should show traces similar to:
 <summary>See more...</summary>
 
 ```shell
-$ idf.py -p /dev/ttyUSB0 monitor
+$ idf.py -B "C:\espbuild" -p /dev/ttyUSB0 monitor
 Executing action: monitor
 Running idf_monitor in directory /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32
 Executing "/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python /esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix xtensa-esp32-elf- --target esp32 --revision 0 /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32/build/azure_iot_freertos_esp32.elf -m '/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python' '/esp/esp-idf/tools/idf.py' '-p' '/dev/ttyUSB0'"...

--- a/demos/projects/ESPRESSIF/esp32/README.md
+++ b/demos/projects/ESPRESSIF/esp32/README.md
@@ -3,8 +3,8 @@
 ## What you need
 
 - [ESPRESSIF ESP32 Board](https://www.espressif.com/en/products/devkits)
-- USB 2.0 A male to Micro USB male cable
-- WiFi Connection
+- Wi-Fi 2.4 GHz
+- USB 2.0 A male to Micro USB male data cable
 - [ESP-IDF](https://idf.espressif.com/) (Version 4.3 for Microsoft Windows or 4.4 for Linux)
 - To run this sample you can use a device previously created in your IoT Hub or have the Azure IoT Middleware for FreeRTOS provision your device automatically using DPS.
 
@@ -59,10 +59,9 @@ To connect the ESPRESSIF ESP32 to Azure, you will update the sample configuratio
 
 The configuration of the ESPRESSIF ESP32 sample uses ESP-IDF' samples standard [kconfig](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/kconfig.html) configuration.
 
-On a [console with ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-4-set-up-the-environment-variables), run the following commands:
+On a [console with ESP-IDF](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html#step-4-set-up-the-environment-variables), navigate to the ESP-Azure IoT Kit project directory: `demos\projects\ESPRESSIF\aziotkit` and run the following commands:
 
 ```shell
-cd demos\projects\ESPRESSIF\esp32
 idf.py menuconfig
 ```
 
@@ -101,12 +100,10 @@ After that, close the configuration utility (`Shift + Q`).
 
 ## Build the image
 
-> This step assumes your are in the ESPRESSIF ESP32 sample directory (same as configuration step above).
-
-To build the device image, run the following command:
+To build the device image, run the following command (the path `"C:\espbuild"` is only a suggestion, feel free to use a different one, as long as it is near your root directory, for a shorter path):
 
   ```bash
-  idf.py build
+  idf.py --no-ccache -B "C:\espbuild" build
   ```
 
 ## Flash the image
@@ -152,7 +149,7 @@ To build the device image, run the following command:
     > This step assumes you are in the ESPRESSIF ESP32 sample directory (same as configuration step above).
 
     ```bash
-    idf.py -p <COM port> flash
+    idf.py --no-ccache -B "C:\espbuild" -p <COM port> flash
     ```
 
     <details>
@@ -161,13 +158,13 @@ To build the device image, run the following command:
     On **Windows**:
 
     ```shell
-    idf.py -p COM5 flash
+    idf.py --no-ccache -B "C:\espbuild" -p COM5 flash
     ```
 
     On **Linux**:
 
     ```shell
-    idf.py -p /dev/ttyUSB0 flash
+    idf.py --no-ccache -B "C:\espbuild" -p /dev/ttyUSB0 flash
     ```
     </details>
 
@@ -178,7 +175,7 @@ You can use any terminal application to monitor the operation of the device and 
 Alternatively you can use ESP-IDF monitor:
 
 ```bash
-idf.py -p <COM port> monitor
+idf.py -B "C:\espbuild" -p <COM port> monitor
 ```
 
 The output should show traces similar to:
@@ -187,7 +184,7 @@ The output should show traces similar to:
 <summary>See more...</summary>
 
 ```shell
-$ idf.py -p /dev/ttyUSB0 monitor
+$ idf.py -B "C:\espbuild" -p /dev/ttyUSB0 monitor
 Executing action: monitor
 Running idf_monitor in directory /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32
 Executing "/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python /esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix xtensa-esp32-elf- --target esp32 --revision 0 /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32/build/azure_iot_freertos_esp32.elf -m '/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python' '/esp/esp-idf/tools/idf.py' '-p' '/dev/ttyUSB0'"...

--- a/demos/projects/ESPRESSIF/esp32/README.md
+++ b/demos/projects/ESPRESSIF/esp32/README.md
@@ -164,7 +164,7 @@ To build the device image, run the following command (the path `"C:\espbuild"` i
     On **Linux**:
 
     ```shell
-    idf.py --no-ccache -B "C:\espbuild" -p /dev/ttyUSB0 flash
+    idf.py -p /dev/ttyUSB0 flash
     ```
     </details>
 
@@ -184,7 +184,7 @@ The output should show traces similar to:
 <summary>See more...</summary>
 
 ```shell
-$ idf.py -B "C:\espbuild" -p /dev/ttyUSB0 monitor
+$ idf.py -p /dev/ttyUSB0 monitor
 Executing action: monitor
 Running idf_monitor in directory /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32
 Executing "/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python /esp/esp-idf/tools/idf_monitor.py -p /dev/ttyUSB0 -b 115200 --toolchain-prefix xtensa-esp32-elf- --target esp32 --revision 0 /iot-middleware-freertos-samples-ew/demos/projects/ESPRESSIF/esp32/build/azure_iot_freertos_esp32.elf -m '/home/user/.espressif/python_env/idf4.4_py3.8_env/bin/python' '/esp/esp-idf/tools/idf.py' '-p' '/dev/ttyUSB0'"...


### PR DESCRIPTION
Added workaround for long path issues directly into the samples and get started guides. We should remove them once they're not needed anymore.  