### PR TITLE
update unix time entry

### DIFF
--- a/demos/projects/NXP/mimxrt1060/main.c
+++ b/demos/projects/NXP/mimxrt1060/main.c
@@ -100,7 +100,7 @@ static ethernetif_config_t xEnetConfig =
     .phyHandle  = &xPhyHandle,
     .macAddress = mainConfigMAC_ADDR,
 };
-static uint64_t ulGlobalEntryTime = 1639093301;
+static uint64_t ulGlobalEntryTime = 1673769600;
 
 /*
  * Prototypes for the demos that can be started from this project.

--- a/demos/projects/ST/b-l475e-iot01a/main.c
+++ b/demos/projects/ST/b-l475e-iot01a/main.c
@@ -67,7 +67,7 @@ xSemaphoreHandle xWifiSemaphoreHandle;
 static UART_HandleTypeDef xConsoleUart;
 /* Use by the pseudo random number generator. */
 static UBaseType_t ulNextRand;
-static uint64_t ulGlobalEntryTime = 1639093301;
+static uint64_t ulGlobalEntryTime = 1673769600;
 
 /* Private function prototypes -----------------------------------------------*/
 static void Init_MEM1_Sensors( void );

--- a/demos/projects/ST/stm32h745i-disco/cm7/main.c
+++ b/demos/projects/ST/stm32h745i-disco/cm7/main.c
@@ -28,7 +28,7 @@ static void MPU_Config( void );
 static void MX_RNG_Init( void );
 static void MX_USART3_UART_Init( void );
 static char cPrintString[ 512 ];
-static uint64_t ulGlobalEntryTime = 1639093301;
+static uint64_t ulGlobalEntryTime = 1673769600;
 
 /*
  * Prototypes for the demos that can be started from this project.


### PR DESCRIPTION
The previous entry time was `1639093301` which correlates to Thu Dec 09, 2021. This is done for simplicity of platform specific timing implementations.

This kicks the time to Sun Jan 15, 2023.

[Added an issue to fix this formally.](https://github.com/Azure-Samples/iot-middleware-freertos-samples/issues/133)