### PR TITLE
Corrected path.

### DIFF
--- a/demos/projects/ESPRESSIF/aziotkit/components/azure-iot-middleware-freertos/CMakeLists.txt
+++ b/demos/projects/ESPRESSIF/aziotkit/components/azure-iot-middleware-freertos/CMakeLists.txt
@@ -20,7 +20,7 @@ list(APPEND COMPONENT_SOURCES
 idf_component_get_property(FREERTOS_DIR freertos COMPONENT_DIR)
 
 set(COMPONENT_INCLUDE_DIRS
-    ${FREERTOS_DIR}/include/freertos
+    ${FREERTOS_DIR}/FreeRTOS-Kernel/include/freertos
     ${AZURE_IOT_MIDDLEWARE_FREERTOS}/source/include
     ${AZURE_IOT_MIDDLEWARE_FREERTOS}/source/interface
     ${AZURE_IOT_MIDDLEWARE_FREERTOS}/ports/coreMQTT


### PR DESCRIPTION
## Purpose

* This fix is supposed to resolve [this bug report I have opened](https://github.com/Azure-Samples/iot-middleware-freertos-samples/issues/142).

## Does this introduce a breaking change?

```
[ ] Yes
[ x ] No
```

## Pull Request Type

What kind of change does this Pull Request introduce?

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

* Install ESP-IDF manually on a Linux distro.
*  Get the code.
```
git clone https://github.com/IPlayZed/iot-middleware-freertos-samples
cd ./iot-middleware-freertos-samples
git checkout CmakeLists-fix-for-ESP-IDF-v5-0-dev-1730-g229ed08484
```

* Test the code
Manual testing.
First source the ESP-IDF as the official docs say.
```
cd ./demos/projects/ESPRESSIF/aziotkit
idf.py menuconfig
```

## What to Check
Verify that the following are valid
* Menuconfig should work and appear, contrary to how the linked issue explains the bug.

## Other Information
I suspect that this was due to an ESP-IDF version change.