### PR TITLE
Fix Gate Tests

### DIFF
--- a/.github/scripts/ci_tests_windows.ps1
+++ b/.github/scripts/ci_tests_windows.ps1
@@ -37,7 +37,7 @@ function sample_build
         [string] $additionalFlags
     )
 
-    cmake -DBOARD="$board" -DVENDOR="$vendor" -B"$outdir" -DFREERTOS_PATH="$test_freertos_src" "$additionalFlags" .
+    cmake -G "Visual Studio 17 2022" -A Win32 -DBOARD="$board" -DVENDOR="$vendor" -B"$outdir" -DFREERTOS_PATH="$test_freertos_src" "$additionalFlags" .
     cmake --build "$outdir"
 }
 

--- a/.github/workflows/ms_build.yml
+++ b/.github/workflows/ms_build.yml
@@ -27,10 +27,12 @@ jobs:
       uses: snickerbockers/submodules-init@v4
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v1.1
+      with:
+        vs-version: '[,17)'
 
-    - name: Get specific version CMake, v3.20.1
-      uses: lukka/get-cmake@v3.20.1
+    - name: Get specific version CMake, v3.21.1
+      uses: lukka/get-cmake@v3.21.1
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/ms_build.yml
+++ b/.github/workflows/ms_build.yml
@@ -28,8 +28,6 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-      with:
-        vs-version: '[,17)'
 
     - name: Get specific version CMake, v3.21.1
       uses: lukka/get-cmake@v3.21.1


### PR DESCRIPTION
Windows updated their default build machines to newer versions. The build then started to look for NMake files instead of VS. The updated machines use the newest versions of VS and only CMake Version 3.21.0 can generate VS 2022 files.