### PR TITLE
Do not send properties back on ADU writable properties ACK

### DIFF
--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/inc/azure/iot/az_iot_adu_ota.h
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/inc/azure/iot/az_iot_adu_ota.h
@@ -247,9 +247,6 @@ AZ_NODISCARD az_result az_iot_adu_ota_parse_service_properties(
              after receiving incoming properties.
  * 
  * @param[in] iot_hub_client    A pointer to the #az_iot_hub_client instance.
- * @param[in] update_request    A #az_iot_adu_ota_update_request instance
- *                              previously parsed using 
- *                              `az_iot_adu_ota_parse_service_properties`.
  * @param[in] version           Version of the writable properties.
  * @param[in] status            Azure Plug-and-Play status code for the 
  *                              writable properties acknowledgement. 
@@ -262,7 +259,6 @@ AZ_NODISCARD az_result az_iot_adu_ota_parse_service_properties(
  */
 AZ_NODISCARD az_result az_iot_adu_ota_get_service_properties_response(
     az_iot_hub_client const* iot_hub_client,
-    az_iot_adu_ota_update_request* update_request,
     int32_t version,
     int32_t status,
     az_span payload,

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu_ota.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu_ota.c
@@ -487,14 +487,12 @@ AZ_NODISCARD az_result az_iot_adu_ota_parse_service_properties(
 
 AZ_NODISCARD az_result az_iot_adu_ota_get_service_properties_response(
     az_iot_hub_client const* iot_hub_client,
-    az_iot_adu_ota_update_request* update_request,
     int32_t version,
     int32_t status,
     az_span payload,
     az_span* out_payload)
 {
     _az_PRECONDITION_NOT_NULL(iot_hub_client);
-    _az_PRECONDITION_NOT_NULL(update_request);
     _az_PRECONDITION_VALID_SPAN(payload, 1, false);
     _az_PRECONDITION_NOT_NULL(out_payload);
 
@@ -509,26 +507,9 @@ AZ_NODISCARD az_result az_iot_adu_ota_get_service_properties_response(
           iot_hub_client, &jw,
           AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_SERVICE), status, version, AZ_SPAN_EMPTY));
 
+    // It is not necessary to send the properties back in the acknowledgement.
+    // We opt not to send them to reduce the size of the payload.
     _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
-
-    // Workflow
-    _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_WORKFLOW)));
-    _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));
-    _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_ACTION)));
-    _az_RETURN_IF_FAILED(az_json_writer_append_int32(&jw, update_request->workflow.action));
-    _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_ID)));
-    _az_RETURN_IF_FAILED(az_json_writer_append_string(&jw, update_request->workflow.id));
-    if (!az_span_is_content_equal(update_request->workflow.retry_timestamp, AZ_SPAN_EMPTY))
-    {
-        _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_RETRY_TIMESTAMP)));
-        _az_RETURN_IF_FAILED(az_json_writer_append_string(&jw, update_request->workflow.retry_timestamp));
-    }
-    _az_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
-
-    // updateManifest
-    _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, AZ_SPAN_FROM_STR(AZ_IOT_ADU_OTA_AGENT_PROPERTY_NAME_UPDATE_MANIFEST)));
-    _az_RETURN_IF_FAILED(az_json_writer_append_string(&jw, update_request->update_manifest));
-
     _az_RETURN_IF_FAILED(az_json_writer_append_end_object(&jw));
 
     _az_RETURN_IF_FAILED(az_iot_hub_client_properties_writer_end_response_status(

--- a/libs/azure-iot-middleware-freertos/source/azure_iot_adu_client.c
+++ b/libs/azure-iot-middleware-freertos/source/azure_iot_adu_client.c
@@ -176,7 +176,6 @@ AzureIoTResult_t AzureIoTADUClient_ADUProcessComponent( AzureIoTADUClient_t * px
 
         az_result azres = az_iot_adu_ota_get_service_properties_response(
             &pxAduClient->pxHubClient->_internal.xAzureIoTHubClientCore,
-            &pxAduClient->xUpdateRequest,
             ( int32_t ) ulPropertyVersion,
             200,
             xWritablePropertyResponse,


### PR DESCRIPTION
This was recommended by the ADU team, as well as the PnP PM.
By not sending the properties back on the writable properties ACK,
the response drops in size by more than 90%
(in tests, from 770 bytes to 69 bytes).

## Purpose
Do not send properties back on ADU writable properties ACK

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
