### PR TITLE
change base64 decoder to assume padding chars

### DIFF
--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/core/az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/core/az_base64.c
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
-
 #include <azure/core/az_base64.h>
 #include <azure/core/internal/az_precondition_internal.h>
 
@@ -404,7 +403,7 @@ AZ_NODISCARD az_result
 az_base64_decode(az_span destination_bytes, az_span source_base64_text, int32_t* out_written)
 {
   _az_PRECONDITION_VALID_SPAN(destination_bytes, 1, false);
-  _az_PRECONDITION_VALID_SPAN(source_base64_text, 4, false);
+  _az_PRECONDITION_VALID_SPAN(source_base64_text, 1, false);
   _az_PRECONDITION_NOT_NULL(out_written);
 
   int32_t source_length = az_span_size(source_base64_text);
@@ -413,8 +412,9 @@ az_base64_decode(az_span destination_bytes, az_span source_base64_text, int32_t*
   int32_t destination_length = az_span_size(destination_bytes);
   uint8_t* destination_ptr = az_span_ptr(destination_bytes);
 
-  // The input must be non-empty and a multiple of 4 to be valid.
-  if (source_length == 0 || source_length % 4 != 0)
+  // The input must be non-empty and a minimum of two characters long.
+  // There can only be two assumed padding characters.
+  if (source_length == 0 || source_length % 4 == 1)
   {
     return AZ_ERROR_UNEXPECTED_END;
   }
@@ -440,12 +440,14 @@ az_base64_decode(az_span destination_bytes, az_span source_base64_text, int32_t*
     source_index += 4;
   }
 
-  // We are guaranteed to have an input with at least 4 bytes at this point, with a size that is a
-  // multiple of 4.
-  int32_t i0 = *(source_ptr + source_length - 4);
-  int32_t i1 = *(source_ptr + source_length - 3);
-  int32_t i2 = *(source_ptr + source_length - 2);
-  int32_t i3 = *(source_ptr + source_length - 1);
+  // If length is divisible by four, do nothing. Else, we assume up to two padding characters.
+  int32_t source_length_mod_four = source_length % 4;
+  int32_t i0 = *(source_ptr + source_index);
+  int32_t i1 = *(source_ptr + source_index + 1);
+  int32_t i2 = source_length_mod_four == 2 ? _az_ENCODING_PAD : *(source_ptr + source_index + 2);
+  int32_t i3 = source_length_mod_four == 2 || source_length_mod_four == 3
+      ? _az_ENCODING_PAD
+      : *(source_ptr + source_index + 3);
 
   i0 = _az_base64_decode_array[i0];
   i1 = _az_base64_decode_array[i1];

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/core/az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/core/az_base64.c
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // SPDX-License-Identifier: MIT
+
 #include <azure/core/az_base64.h>
 #include <azure/core/internal/az_precondition_internal.h>
 
@@ -403,7 +404,7 @@ AZ_NODISCARD az_result
 az_base64_decode(az_span destination_bytes, az_span source_base64_text, int32_t* out_written)
 {
   _az_PRECONDITION_VALID_SPAN(destination_bytes, 1, false);
-  _az_PRECONDITION_VALID_SPAN(source_base64_text, 1, false);
+  _az_PRECONDITION_VALID_SPAN(source_base64_text, 2, false);
   _az_PRECONDITION_NOT_NULL(out_written);
 
   int32_t source_length = az_span_size(source_base64_text);

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu.c
@@ -241,9 +241,9 @@ AZ_NODISCARD az_result az_iot_adu_get_properties_payload(
       // Taking from the end of the remaining buffer to avoid az_json_writer overlapping
       // with the data we will generate in that buffer.
       az_span step_id = az_span_slice_to_end(
-          remaining_buffer, az_span_size(remaining_buffer) - RESULT_STEP_ID_MAX_SIZE);
+          remaining_buffer, az_span_size(remaining_buffer) - (int32_t)RESULT_STEP_ID_MAX_SIZE);
 
-      _az_RETURN_IF_FAILED(generate_step_id(step_id, i, &step_id));
+      _az_RETURN_IF_FAILED(generate_step_id(step_id, (uint32_t)i, &step_id));
 
       _az_RETURN_IF_FAILED(az_json_writer_append_property_name(&jw, step_id));
       _az_RETURN_IF_FAILED(az_json_writer_append_begin_object(&jw));

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
@@ -165,11 +165,17 @@ static void az_base64_decode_test(void** state)
 
   uint8_t expected_buffer1[1] = { 1 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQ=="), AZ_SPAN_FROM_BUFFER(expected_buffer1));
+  uint8_t expected_buffer0[1] = { 1 };
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQ"), AZ_SPAN_FROM_BUFFER(expected_buffer0));
   uint8_t expected_buffer2[2] = { 1, 2 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQI="), AZ_SPAN_FROM_BUFFER(expected_buffer2));
   uint8_t expected_buffer3[3] = { 1, 2, 3 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQID"), AZ_SPAN_FROM_BUFFER(expected_buffer3));
   uint8_t expected_buffer4[4] = { 1, 2, 3, 4 };
+  // Test two short padding characters
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA"), AZ_SPAN_FROM_BUFFER(expected_buffer4));
+  // Test one short padding character
+  _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   _az_base64_decode_test_helper(
       AZ_SPAN_FROM_STR("AQIDBA=="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   uint8_t expected_buffer5[5] = { 1, 2, 3, 4, 5 };
@@ -244,21 +250,6 @@ static void az_base64_decode_source_small_test(void** state)
 
   assert_int_equal(
       az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDB"), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBA"), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBA="), &bytes_written),
-      AZ_ERROR_UNEXPECTED_END);
-  assert_int_equal(bytes_written, 0);
-
-  assert_int_equal(
-      az_base64_decode(destination, AZ_SPAN_FROM_STR("AQIDBAU"), &bytes_written),
       AZ_ERROR_UNEXPECTED_END);
   assert_int_equal(bytes_written, 0);
 }

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
@@ -172,7 +172,7 @@ static void az_base64_decode_test(void** state)
   uint8_t expected_buffer3[3] = { 1, 2, 3 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQID"), AZ_SPAN_FROM_BUFFER(expected_buffer3));
   uint8_t expected_buffer4[4] = { 1, 2, 3, 4 };
-  // Can't have three short padding characters so test below for AQIDB returns AZ_ERROR_UNEXPECTED_END
+  // Can't have three short padding characters, so test later for "AQIDB" returns AZ_ERROR_UNEXPECTED_END
   // Assume 2 padding
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA"), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   // Assume 1 padding

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "az_test_definitions.h"
+#include <az_test_precondition.h>
 #include <azure/core/az_base64.h>
+#include <azure/core/az_precondition.h>
 
 #include <setjmp.h>
 #include <stdarg.h>
@@ -11,6 +13,22 @@
 #include <cmocka.h>
 
 #include <azure/core/_az_cfg.h>
+
+#ifndef AZ_NO_PRECONDITION_CHECKING
+ENABLE_PRECONDITION_CHECK_TESTS()
+
+static void az_base64_decode_precondition_failed()
+{
+  uint8_t destination_buffer[10];
+  az_span destination = AZ_SPAN_FROM_BUFFER(destination_buffer);
+
+  int32_t bytes_written = 0;
+
+  ASSERT_PRECONDITION_CHECKED(az_base64_decode(destination, AZ_SPAN_FROM_STR(""), &bytes_written));
+  ASSERT_PRECONDITION_CHECKED(az_base64_decode(destination, AZ_SPAN_FROM_STR("A"), &bytes_written));
+}
+
+#endif // AZ_NO_PRECONDITION_CHECKING
 
 static void az_base64_max_encode_test(void** state)
 {
@@ -172,8 +190,8 @@ static void az_base64_decode_test(void** state)
   uint8_t expected_buffer3[3] = { 1, 2, 3 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQID"), AZ_SPAN_FROM_BUFFER(expected_buffer3));
   uint8_t expected_buffer4[4] = { 1, 2, 3, 4 };
-  // Can't have three short padding characters, so test later for "AQIDB" returns AZ_ERROR_UNEXPECTED_END
-  // Assume 2 padding
+  // Can't have three short padding characters, so test later for "AQIDB" returns
+  // AZ_ERROR_UNEXPECTED_END Assume 2 padding
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA"), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   // Assume 1 padding
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
@@ -340,7 +358,14 @@ static void az_base64_decode_invalid_test(void** state)
 
 int test_az_base64()
 {
+#ifndef AZ_NO_PRECONDITION_CHECKING
+  SETUP_PRECONDITION_CHECK_TESTS();
+#endif // AZ_NO_PRECONDITION_CHECKING
+
   const struct CMUnitTest tests[] = {
+#ifndef AZ_NO_PRECONDITION_CHECKING
+    cmocka_unit_test(az_base64_decode_precondition_failed),
+#endif // AZ_NO_PRECONDITION_CHECKING
     cmocka_unit_test(az_base64_max_encode_test),
     cmocka_unit_test(az_base64_max_decode_test),
     cmocka_unit_test(az_base64_encode_test),

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/tests/core/test_az_base64.c
@@ -172,10 +172,12 @@ static void az_base64_decode_test(void** state)
   uint8_t expected_buffer3[3] = { 1, 2, 3 };
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQID"), AZ_SPAN_FROM_BUFFER(expected_buffer3));
   uint8_t expected_buffer4[4] = { 1, 2, 3, 4 };
-  // Test two short padding characters
+  // Can't have three short padding characters so test below for AQIDB returns AZ_ERROR_UNEXPECTED_END
+  // Assume 2 padding
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA"), AZ_SPAN_FROM_BUFFER(expected_buffer4));
-  // Test one short padding character
+  // Assume 1 padding
   _az_base64_decode_test_helper(AZ_SPAN_FROM_STR("AQIDBA="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
+  // Assume 0 padding
   _az_base64_decode_test_helper(
       AZ_SPAN_FROM_STR("AQIDBA=="), AZ_SPAN_FROM_BUFFER(expected_buffer4));
   uint8_t expected_buffer5[5] = { 1, 2, 3, 4, 5 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36710865/173239291-5ec3cf03-88e5-444b-90cc-d596ea5fd9b4.png)

To verify tests, run the following:
```bash
cd libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c
mkdir build
cmake -DUNIT_TESTING=ON ..
cmake --build .
ctest --output-on-failure
```