### PR TITLE
Do not expose ADU service compatibility properties

### DIFF
--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/inc/azure/iot/az_iot_adu_client.h
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/inc/azure/iot/az_iot_adu_client.h
@@ -108,12 +108,6 @@ typedef struct
 
 typedef struct
 {
-  az_span device_manufacturer;
-  az_span device_model;
-} az_iot_adu_client_update_manifest_compatibility;
-
-typedef struct
-{
   az_span installed_criteria;
 } az_iot_adu_client_update_manifest_instructions_step_handler_properties;
 
@@ -155,9 +149,6 @@ typedef struct
 {
   az_span manifest_version;
   az_iot_adu_client_update_id update_id;
-  // TODO: confirm compat is always through manufacturer and model.
-  //       It might not be, so this needs to be a generic property bag instead.
-  az_iot_adu_client_update_manifest_compatibility compatibility;
   az_iot_adu_client_update_manifest_instructions instructions;
   az_iot_adu_client_update_manifest_file files[AZ_IOT_ADU_CLIENT_MAX_FILE_URL_COUNT];
   uint32_t files_count;

--- a/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu_client.c
+++ b/libs/azure-iot-middleware-freertos/libraries/azure-sdk-for-c/sdk/src/azure/iot/az_iot_adu_client.c
@@ -628,8 +628,6 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
   update_manifest->update_id.name = AZ_SPAN_EMPTY;
   update_manifest->update_id.provider = AZ_SPAN_EMPTY;
   update_manifest->update_id.version = AZ_SPAN_EMPTY;
-  update_manifest->compatibility.device_manufacturer = AZ_SPAN_EMPTY;
-  update_manifest->compatibility.device_model = AZ_SPAN_EMPTY;
   update_manifest->instructions.steps_count = 0;
   update_manifest->files_count = 0;
   update_manifest->create_date_time = AZ_SPAN_EMPTY;
@@ -814,44 +812,12 @@ AZ_NODISCARD az_result az_iot_adu_client_parse_update_manifest(
                  &ref_json_reader->token,
                  AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_COMPATIBILITY)))
     {
-      // TODO: parse this as a map (dictionary) instead.
-      _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-      RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_BEGIN_ARRAY);
-      _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-      RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_BEGIN_OBJECT);
-      _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-
-      while (ref_json_reader->token.kind != AZ_JSON_TOKEN_END_OBJECT)
-      {
-        RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_PROPERTY_NAME);
-
-        if (az_json_token_is_text_equal(
-                &ref_json_reader->token,
-                AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DEVICE_MANUFACTURER)))
-        {
-          _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-          RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_STRING);
-          update_manifest->compatibility.device_manufacturer = ref_json_reader->token.slice;
-        }
-        else if (az_json_token_is_text_equal(
-                     &ref_json_reader->token,
-                     AZ_SPAN_FROM_STR(AZ_IOT_ADU_CLIENT_AGENT_PROPERTY_NAME_DEVICE_MODEL)))
-        {
-          _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-          RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_STRING);
-          update_manifest->compatibility.device_model = ref_json_reader->token.slice;
-        }
-        else
-        {
-          // TODO: parse compat as map, and do not return this failure.
-          return AZ_ERROR_JSON_INVALID_STATE;
-        }
-
-        _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-      }
-
-      _az_RETURN_IF_FAILED(az_json_reader_next_token(ref_json_reader));
-      RETURN_IF_JSON_TOKEN_NOT_TYPE((ref_json_reader), AZ_JSON_TOKEN_END_ARRAY);
+      /*
+       * According to ADU design, the ADU service compatibility properties
+       * are not intended to be consumed by the ADU agent.
+       * To save on processing, the properties are not being exposed.
+       */
+      _az_RETURN_IF_FAILED(az_json_reader_skip_children(ref_json_reader));
     }
     else if (az_json_token_is_text_equal(
                  &ref_json_reader->token,

--- a/libs/azure-iot-middleware-freertos/source/azure_iot_adu_client.c
+++ b/libs/azure-iot-middleware-freertos/source/azure_iot_adu_client.c
@@ -170,11 +170,6 @@ static void prvCastUpdateRequest( az_iot_adu_client_update_request * pxBaseUpdat
     pxUpdateRequest->xUpdateManifest.xUpdateId.pucVersion = az_span_ptr( pxBaseUpdateManifest->update_id.version );
     pxUpdateRequest->xUpdateManifest.xUpdateId.ulVersionLength = ( uint32_t ) az_span_size( pxBaseUpdateManifest->update_id.version );
 
-    pxUpdateRequest->xUpdateManifest.xCompatibility.pucDeviceManufacturer = az_span_ptr( pxBaseUpdateManifest->compatibility.device_manufacturer );
-    pxUpdateRequest->xUpdateManifest.xCompatibility.ulDeviceManufacturerLength = ( uint32_t ) az_span_size( pxBaseUpdateManifest->compatibility.device_manufacturer );
-    pxUpdateRequest->xUpdateManifest.xCompatibility.pucDeviceModel = az_span_ptr( pxBaseUpdateManifest->compatibility.device_model );
-    pxUpdateRequest->xUpdateManifest.xCompatibility.ulDeviceModelLength = ( uint32_t ) az_span_size( pxBaseUpdateManifest->compatibility.device_model );
-
     pxUpdateRequest->xUpdateManifest.xInstructions.ulStepsCount = pxBaseUpdateManifest->instructions.steps_count;
 
     for( uint32_t ulStepIndex = 0; ulStepIndex < pxBaseUpdateManifest->instructions.steps_count; ulStepIndex++ )

--- a/libs/azure-iot-middleware-freertos/source/include/azure_iot_adu_client.h
+++ b/libs/azure-iot-middleware-freertos/source/include/azure_iot_adu_client.h
@@ -256,14 +256,6 @@ typedef struct AzureIoTADUUpdateId
     uint32_t ulVersionLength;
 } AzureIoTADUUpdateId_t;
 
-typedef struct AzureIoTADUCompatibility
-{
-    uint8_t * pucDeviceManufacturer;
-    uint32_t ulDeviceManufacturerLength;
-    uint8_t * pucDeviceModel;
-    uint32_t ulDeviceModelLength;
-} AzureIoTADUCompatibility_t;
-
 typedef struct AzureIoTADUInstructionStepFile
 {
     uint8_t * pucFileName;
@@ -308,7 +300,6 @@ typedef struct AzureIoTADUInstructions
 typedef struct AzureIoTADUUpdateManifest
 {
     AzureIoTADUUpdateId_t xUpdateId;
-    AzureIoTADUCompatibility_t xCompatibility;
     AzureIoTADUInstructions_t xInstructions;
     uint32_t ulFilesCount;
     AzureIoTADUUpdateManifestFile_t pxFiles[ AZ_IOT_ADU_CLIENT_MAX_FILE_URL_COUNT ];


### PR DESCRIPTION
## Purpose
According to ADU design the ADU service compatibility properties
do not need to be parsed by the ADU agent; this change ignores the
ADU service compatibility properties and do not expose them to the
user.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

