### PR TITLE
Fix for ESP32 ADU sample to use installedCriteria for version comparison

### DIFF
--- a/demos/projects/ESPRESSIF/adu/config/demo_config.h
+++ b/demos/projects/ESPRESSIF/adu/config/demo_config.h
@@ -492,6 +492,6 @@ static unsigned char root_cert_array[] = {
 #define democonfigADU_DEVICE_MODEL        "ESP32-Azure-IoT-Kit"
 #define democonfigADU_UPDATE_PROVIDER     "ESPRESSIF"
 #define democonfigADU_UPDATE_NAME         "ESP32-Azure-IoT-Kit"
-#define democonfigADU_UPDATE_VERSION      "1.0"
+#define democonfigADU_UPDATE_VERSION      "1.1"
 
 #endif /* DEMO_CONFIG_H */

--- a/demos/sample_azure_iot_adu/sample_azure_iot_pnp_simulated_data.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_pnp_simulated_data.c
@@ -243,7 +243,7 @@ static uint32_t prvGetNewMaxTemp( double xUpdatedTemperature,
  * @return true If the current image version matches the installedCriteria. 
  * @return false If the current image version does not match the installedCriteria. 
  */
-static bool prvDoesInstallationCriteriaMatchCurrentVersion( const AzureIoTADUUpdateRequest_t * pxAduUpdateRequest )
+static bool prvDoesInstalledCriteriaMatchCurrentVersion( const AzureIoTADUUpdateRequest_t * pxAduUpdateRequest )
 {
     /*
      * In a production solution, each step should be validated against the version of
@@ -279,9 +279,9 @@ static bool prvDoesInstallationCriteriaMatchCurrentVersion( const AzureIoTADUUpd
  */
 static AzureIoTADURequestDecision_t prvUserDecideShouldStartUpdate( AzureIoTADUUpdateRequest_t * pxAduUpdateRequest )
 {
-    if( !prvDoesInstallationCriteriaMatchCurrentVersion( pxAduUpdateRequest ) )
+    if( !prvDoesInstalledCriteriaMatchCurrentVersion( pxAduUpdateRequest ) )
     {
-        LogInfo( ( "[ADU] Rejecting update request (current version is up-to-date)" ) );
+        LogInfo( ( "[ADU] Rejecting update request (installed criteria does not match current version)" ) );
         return eAzureIoTADURequestDecisionReject;
     }
     else

--- a/demos/sample_azure_iot_adu/sample_azure_iot_pnp_simulated_data.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_pnp_simulated_data.c
@@ -238,10 +238,10 @@ static uint32_t prvGetNewMaxTemp( double xUpdatedTemperature,
 /**
  * @brief Verifies if the current image version matches the "installedCriteria" version in the
  *        installation step of the ADU Update Manifest.
- * 
+ *
  * @param pxAduUpdateRequest Parsed update request, with the ADU update manifest.
- * @return true If the current image version matches the installedCriteria. 
- * @return false If the current image version does not match the installedCriteria. 
+ * @return true If the current image version matches the installedCriteria.
+ * @return false If the current image version does not match the installedCriteria.
  */
 static bool prvDoesInstalledCriteriaMatchCurrentVersion( const AzureIoTADUUpdateRequest_t * pxAduUpdateRequest )
 {
@@ -249,12 +249,12 @@ static bool prvDoesInstalledCriteriaMatchCurrentVersion( const AzureIoTADUUpdate
      * In a production solution, each step should be validated against the version of
      * each component the update step applies to (matching through the `handler` name).
      */
-    if ( xADUDeviceProperties.xCurrentUpdateId.ulVersionLength ==
-         pxAduUpdateRequest->xUpdateManifest.xInstructions.pxSteps[ 0 ].ulInstalledCriteriaLength &&
-         ( strncmp(
-            ( const char * ) xADUDeviceProperties.xCurrentUpdateId.ucVersion,
-            ( const char * ) pxAduUpdateRequest->xUpdateManifest.xInstructions.pxSteps[ 0 ].pucInstalledCriteria,
-            ( size_t ) xADUDeviceProperties.xCurrentUpdateId.ulVersionLength ) == 0 ) )
+    if( ( xADUDeviceProperties.xCurrentUpdateId.ulVersionLength ==
+          pxAduUpdateRequest->xUpdateManifest.xInstructions.pxSteps[ 0 ].ulInstalledCriteriaLength ) &&
+        ( strncmp(
+              ( const char * ) xADUDeviceProperties.xCurrentUpdateId.ucVersion,
+              ( const char * ) pxAduUpdateRequest->xUpdateManifest.xInstructions.pxSteps[ 0 ].pucInstalledCriteria,
+              ( size_t ) xADUDeviceProperties.xCurrentUpdateId.ulVersionLength ) == 0 ) )
     {
         return true;
     }


### PR DESCRIPTION
## Purpose
Fix for github issue
https://github.com/Azure-Samples/iot-middleware-freertos-samples/issues/210

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Just run the ESP32 ADU sample as usual.

## What to Check
Verify the update happens as expected from version 1.0 to 1.1, and the update request gets rejected after the device boots up with the new image version (1.1).


## Other Information
<!-- Add any other helpful information that may be needed here. -->