### PR TITLE
remove stale log

### DIFF
--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -291,19 +291,6 @@ static void prvDispatchPropertiesUpdate( AzureIoTHubClientPropertiesResponse_t *
                                ucReportedPropertiesUpdate,
                                sizeof( ucReportedPropertiesUpdate ),
                                &ulReportedPropertiesUpdateLength );
-
-    if( ulReportedPropertiesUpdateLength == 0 )
-    {
-        LogError( ( "Failed to send response to writable properties update, length of response is zero." ) );
-    }
-    else
-    {
-        AzureIoTResult_t xResult = AzureIoTHubClient_SendPropertiesReported( &xAzureIoTHubClient,
-                                                                             ucReportedPropertiesUpdate,
-                                                                             ulReportedPropertiesUpdateLength,
-                                                                             NULL );
-        configASSERT( xResult == eAzureIoTSuccess );
-    }
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
The response is handled inside the `vHandleWritableProperties()` function so no response is needed from this function.

https://github.com/Azure-Samples/iot-middleware-freertos-samples/blob/c7ff54f4ae986f447dd888072f6e658c6c544917/demos/projects/ESPRESSIF/adu/main/azure_iot_freertos_esp32_pnp_model.c#L276-L289