### PR TITLE
fix todos

### DIFF
--- a/demos/projects/NXP/mimxrt1060/config/demo_config.h
+++ b/demos/projects/NXP/mimxrt1060/config/demo_config.h
@@ -486,7 +486,6 @@ static unsigned char root_cert_array[] = {
 
 #define democonfigCHUNK_DOWNLOAD_SIZE   4096
 
-// TODO: Fill in values for NXP versions
 #define democonfigADU_DEVICE_MANUFACTURER "NXP"
 #define democonfigADU_DEVICE_MODEL        "MIMXRT1060"
 #define democonfigADU_UPDATE_PROVIDER     "NXP"

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -208,7 +208,6 @@ static AzureIoTHubClientComponent_t pnp_components[ sampleaduPNP_COMPONENTS_LIST
 /* OTA update on the Azure Device Update portal. */
 #define sampleaduSAMPLE_EXTENDED_RESULT_CODE    1234
 
-/* TODO: REMOVE THIS BLOCKER ONCE ADU IS IMPLEMENTED */
 /* This does not affect devices that actually implement the ADU process */
 /* as they will reboot before getting to the place where this is used. */
 bool xDidDeviceUpdate = false;


### PR DESCRIPTION
Remaining TODOs are:

- In the NXP flash platform (which we will leave as TODOs for developers to implement themselves)
- In the JWS verification for a valid PKCS7 parser which we don't have. That will stay for now.