### PR TITLE
Add warnings about hub scale units that support ADU

### DIFF
--- a/demos/projects/ESPRESSIF/adu/README.md
+++ b/demos/projects/ESPRESSIF/adu/README.md
@@ -216,6 +216,7 @@ To create an Azure Device Update instance and connect it to your IoT Hub, please
 For other prerequisite help, please see the links below. If none of the links apply to your development environment, you may skip them.
 
 - [Create an Azure IoT Hub](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-through-portal)
+  > Important: To use Azure Device Update you must have an Azure IoT Hub with [scale unit](https://learn.microsoft.com/azure/iot-hub/iot-hub-scaling) S1, S2, S3 or a free/standard hub. This sample will not work with a Basic Azure IoT Hub scale unit.
 - [Create Device Provisioning Service Instance](https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision)
 
 ## Deploy the Over the Air Update

--- a/demos/projects/PC/linux/ADU.md
+++ b/demos/projects/PC/linux/ADU.md
@@ -133,6 +133,7 @@ To create an Azure Device Update instance and connect it to your IoT Hub, please
 For other prerequisite help, please see the links below. If none of the links apply to your development environment, you may skip them.
 
 - [Create an Azure IoT Hub.](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-through-portal)
+  > Important: To use Azure Device Update you must have an Azure IoT Hub with [scale unit](https://learn.microsoft.com/azure/iot-hub/iot-hub-scaling) S1, S2, S3 or a free/standard hub. This sample will not work with a Basic Azure IoT Hub scale unit.
 - [Create Device Provisioning Service Instance.](https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision)
 
 ## Deploy the Over the Air Update

--- a/demos/projects/ST/b-l475e-iot01a/ADU.md
+++ b/demos/projects/ST/b-l475e-iot01a/ADU.md
@@ -153,6 +153,7 @@ To create an Azure Device Update instance and connect it to your IoT Hub, please
 For other prerequisite help, please see the links below. If none of the links apply to your development environment, you may skip them.
 
 - [Create an Azure IoT Hub](https://docs.microsoft.com/azure/iot-hub/iot-hub-create-through-portal)
+  > Important: To use Azure Device Update you must have an Azure IoT Hub with [scale unit](https://learn.microsoft.com/azure/iot-hub/iot-hub-scaling) S1, S2, S3 or a free/standard hub. This sample will not work with a Basic Azure IoT Hub scale unit.
 - [Create Device Provisioning Service Instance](https://docs.microsoft.com/azure/iot-dps/quick-setup-auto-provision)
 
 ## Deploy the Over the Air Update


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
Add a warning to the ADU samples mentioning the supported IoT Hub scale units.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Verify the ST L475, ESP32 and Linux ADU samples if they have a warning regarding the scale units supported for the IoT Hub

## What to Check
Verify that the following text is displayed:
"Important: To use Azure Device Update you must have an Azure IoT Hub with [scale unit](https://learn.microsoft.com/azure/iot-hub/iot-hub-scaling) S1, S2, S3 or a free/standard hub. This sample will not work with a Basic Azure IoT Hub scale unit."

## Other Information
If you got a stubborn jar you can't open, use a [spoon](https://www.popsugar.com/food/How-Open-Jar-Spoon-1645684)!