### PR TITLE
Remove printfs from verifyImage

### DIFF
--- a/demos/projects/ESPRESSIF/adu/port/azure_iot_flash_platform.c
+++ b/demos/projects/ESPRESSIF/adu/port/azure_iot_flash_platform.c
@@ -50,7 +50,7 @@ AzureIoTResult_t AzureIoTPlatform_Init( AzureADUImage_t * const pxAduImage )
 
     if( pxCurrentPartition == NULL )
     {
-        printf( ( "esp_ota_get_running_partition failed" ) );
+        AZLogError( ( "esp_ota_get_running_partition failed" ) );
         return eAzureIoTErrorFailed;
     }
 
@@ -62,7 +62,7 @@ AzureIoTResult_t AzureIoTPlatform_Init( AzureADUImage_t * const pxAduImage )
 
     if( pxAduImage->xUpdatePartition == NULL )
     {
-        printf( ( "esp_ota_get_next_update_partition failed" ) );
+        AZLogError( ( "esp_ota_get_next_update_partition failed" ) );
         return eAzureIoTErrorFailed;
     }
 
@@ -149,17 +149,9 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
         ( void ) espErr;
 
         mbedtls_md_update( &ctx, ( const unsigned char * ) ucPartitionReadBuffer, ulReadSize );
-
-        if( ( ulOffset % 65536 == 0 ) && ( ulOffset != 0 ) )
-        {
-            printf( "." );
-            fflush( stdout );
-        }
     }
 
-    printf( "\r\n" );
-
-    AZLogInfo( ( "Done\r\n" ) );
+    AZLogInfo( ( "mbedtls calculation completed\r\n" ) );
 
     mbedtls_md_finish( &ctx, ucCalculatedHash );
     mbedtls_md_free( &ctx );
@@ -176,18 +168,18 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            printf( "%x", ucDecodedManifestHash[ i ] );
+            AZLogInfo( ( "%x", ucDecodedManifestHash[ i ] ) );
         }
 
-        printf( ( "\r\n" ) );
+        AZLogInfo( ( "\r\n" ) );
         AZLogInfo( ( "Calculated: " ) );
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            printf( "%x", ucCalculatedHash[ i ] );
+            AZLogInfo( ( "%x", ucCalculatedHash[ i ] ) );
         }
 
-        printf( ( "\r\n" ) );
+        AZLogInfo( ( "\r\n" ) );
 
         xResult = eAzureIoTErrorFailed;
     }

--- a/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
+++ b/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
@@ -215,7 +215,7 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            AZLogInfo( "%x", ucDecodedManifestHash[ i ] );
+            AZLogInfo( ( "%x", ucDecodedManifestHash[ i ] ) );
         }
 
         AZLogInfo( ( "\r\n" ) );
@@ -223,7 +223,7 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            AZLogInfo( "%x", ucCalculatedHash[ i ] );
+            AZLogInfo( ( "%x", ucCalculatedHash[ i ] ) );
         }
 
         AZLogInfo( ( "\r\n" ) );

--- a/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
+++ b/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
@@ -196,17 +196,9 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
         memcpy( ucPartitionReadBuffer, ( pxAduImage->xUpdatePartition + ulOffset ), ulReadSize );
 
         mbedtls_md_update( &ctx, ( const unsigned char * ) ucPartitionReadBuffer, ulReadSize );
-
-        if( ( ulOffset % 65536 == 0 ) && ( ulOffset != 0 ) )
-        {
-            printf( "." );
-            fflush( stdout );
-        }
     }
 
-    printf( "\r\n" );
-
-    AZLogInfo( ( "Done\r\n" ) );
+    AZLogInfo( ( "mbedtls calculation completed\r\n" ) );
 
     mbedtls_md_finish( &ctx, ucCalculatedHash );
     mbedtls_md_free( &ctx );
@@ -223,18 +215,18 @@ AzureIoTResult_t AzureIoTPlatform_VerifyImage( AzureADUImage_t * const pxAduImag
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            printf( "%x", ucDecodedManifestHash[ i ] );
+            AZLogInfo( "%x", ucDecodedManifestHash[ i ] );
         }
 
-        printf( ( "\r\n" ) );
+        AZLogInfo( ( "\r\n" ) );
         AZLogInfo( ( "Calculated: " ) );
 
         for( int i = 0; i < azureiotflashSHA_256_SIZE; ++i )
         {
-            printf( "%x", ucCalculatedHash[ i ] );
+            AZLogInfo( "%x", ucCalculatedHash[ i ] );
         }
 
-        printf( ( "\r\n" ) );
+        AZLogInfo( ( "\r\n" ) );
 
         xResult = eAzureIoTErrorFailed;
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
REmove `printf` from functions in azure_iot_flash_platform.c file**S**

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the ADU samples for ESP32 and ST L475 and verify logs.

## What to Check
Verify that the following are valid:
No breaks in functionality due to logging changes.
And that the similar prints are still logged (timestamps and image size may vary):

I (88168) AZ IOT: Starting the mbedtls calculation: image size 866304
I (94258) AZ IOT: mbedtls calculation completed

## Other Information
Lint collected in your dryer's vent can be a fire hazard! [Clean them regularly](https://www.lowes.com/n/how-to/clean-a-dryer-vent)!