### PR TITLE
Update ADU samples configs to reflect their non-production nature

### DIFF
--- a/demos/projects/ESPRESSIF/adu/README.md
+++ b/demos/projects/ESPRESSIF/adu/README.md
@@ -260,7 +260,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 
 Import-Module .\iot-hub-device-update\tools\AduCmdlets\AduUpdate.psm1
 
-$updateId = New-AduUpdateId -Provider "ESPRESSIF" -Name "ESP32-Azure-IoT-Kit" -Version 1.1
+$updateId = New-AduUpdateId -Provider "Contoso" -Name "ESP32-Azure-IoT-Kit" -Version 1.1
 
 $compat = New-AduUpdateCompatibility -Properties @{ deviceManufacturer = 'ESPRESSIF'; deviceModel = 'ESP32-Azure-IoT-Kit' }
 
@@ -274,11 +274,11 @@ $update | Out-File "./$($updateId.provider).$($updateId.name).$($updateId.versio
 Verify you have the following files in your ADU-update directory:
 
 - `azure_iot_freertos_esp32-v1.1.bin`
-- `ESPRESSIF.ESP32-Azure-IoT-Kit.1.1.importmanifest.json`
+- `Contoso.ESP32-Azure-IoT-Kit.1.1.importmanifest.json`
 
 ### Import the Update Manifest
 
-To import the update (`azure_iot_freertos_esp32-v1.1.bin`) and manifest (`ESPRESSIF.ESP32-Azure-IoT-Kit.1.1.importmanifest.json`), follow the instructions at the link below:
+To import the update (`azure_iot_freertos_esp32-v1.1.bin`) and manifest (`Contoso.ESP32-Azure-IoT-Kit.1.1.importmanifest.json`), follow the instructions at the link below:
 
 - [Import Update and Manifest](https://docs.microsoft.com/azure/iot-hub-device-update/import-update)
 

--- a/demos/projects/ESPRESSIF/adu/config/demo_config.h
+++ b/demos/projects/ESPRESSIF/adu/config/demo_config.h
@@ -492,7 +492,7 @@ static unsigned char root_cert_array[] = {
 
 #define democonfigADU_DEVICE_MANUFACTURER "ESPRESSIF"
 #define democonfigADU_DEVICE_MODEL        "ESP32-Azure-IoT-Kit"
-#define democonfigADU_UPDATE_PROVIDER     "ESPRESSIF"
+#define democonfigADU_UPDATE_PROVIDER     "Contoso"
 #define democonfigADU_UPDATE_NAME         "ESP32-Azure-IoT-Kit"
 #define democonfigADU_UPDATE_VERSION      "1.0"
 

--- a/demos/projects/NXP/mimxrt1060/config/demo_config.h
+++ b/demos/projects/NXP/mimxrt1060/config/demo_config.h
@@ -488,7 +488,7 @@ static unsigned char root_cert_array[] = {
 
 #define democonfigADU_DEVICE_MANUFACTURER "NXP"
 #define democonfigADU_DEVICE_MODEL        "MIMXRT1060"
-#define democonfigADU_UPDATE_PROVIDER     "NXP"
+#define democonfigADU_UPDATE_PROVIDER     "Contoso"
 #define democonfigADU_UPDATE_NAME         "MIMXRT1060"
 #define democonfigADU_UPDATE_VERSION      "1.0"
 

--- a/demos/projects/PC/linux/ADU.md
+++ b/demos/projects/PC/linux/ADU.md
@@ -175,7 +175,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 
 Import-Module .\iot-hub-device-update\tools\AduCmdlets\AduUpdate.psm1
 
-$updateId = New-AduUpdateId -Provider "PC" -Name "Linux" -Version 1.1
+$updateId = New-AduUpdateId -Provider "Contoso" -Name "Linux" -Version 1.1
 
 $compat = New-AduUpdateCompatibility -Properties @{ deviceManufacturer = 'PC'; deviceModel = 'Linux' }
 
@@ -189,11 +189,11 @@ $update | Out-File "./$($updateId.provider).$($updateId.name).$($updateId.versio
 Verify you have the following files in your ADU-update directory:
 
 - `iot-middleware-sample-adu-v1-1`
-- `PC.Linux.1.1.importmanifest.json`
+- `Contoso.Linux.1.1.importmanifest.json`
 
 ### Import the Update Manifest
 
-To import the update (`iot-middleware-sample-adu-v1-1`) and manifest (`PC.Linux.1.1.importmanifest.json`), follow the instructions at the link below:
+To import the update (`iot-middleware-sample-adu-v1-1`) and manifest (`Contoso.Linux.1.1.importmanifest.json`), follow the instructions at the link below:
 
 - [Import Update and Manifest.](https://docs.microsoft.com/azure/iot-hub-device-update/import-update)
 

--- a/demos/projects/PC/linux/config/demo_config.h
+++ b/demos/projects/PC/linux/config/demo_config.h
@@ -488,7 +488,7 @@ static unsigned char root_cert_array[] = {
 
 #define democonfigADU_DEVICE_MANUFACTURER "PC"
 #define democonfigADU_DEVICE_MODEL        "Linux"
-#define democonfigADU_UPDATE_PROVIDER     "PC"
+#define democonfigADU_UPDATE_PROVIDER     "Contoso"
 #define democonfigADU_UPDATE_NAME         "Linux"
 #define democonfigADU_UPDATE_VERSION      "1.0"
 #define democonfigADU_UPDATE_NEW_VERSION  "1.1"

--- a/demos/projects/ST/b-l475e-iot01a/ADU.md
+++ b/demos/projects/ST/b-l475e-iot01a/ADU.md
@@ -195,7 +195,7 @@ Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
 
 Import-Module .\iot-hub-device-update\tools\AduCmdlets\AduUpdate.psm1
 
-$updateId = New-AduUpdateId -Provider "STMicroelectronics" -Name "STM32L475" -Version 1.1
+$updateId = New-AduUpdateId -Provider "Contoso" -Name "STM32L475" -Version 1.1
 
 $compat = New-AduUpdateCompatibility -Properties @{ deviceManufacturer = 'STMicroelectronics'; deviceModel = 'STM32L475' }
 
@@ -209,11 +209,11 @@ $update | Out-File "./$($updateId.provider).$($updateId.name).$($updateId.versio
 Verify you have the following files in your ADU-update directory:
 
 - `iot-middleware-sample-adu-v1.1.bin`
-- `STMicroelectronics.STM32L475.1.1.importmanifest.json`
+- `Contoso.STM32L475.1.1.importmanifest.json`
 
 ### Import the Update Manifest
 
-To import the update (`iot-middleware-sample-adu-v1.1.bin`) and manifest (`STMicroelectronics.STM32L475.1.1.importmanifest.json`), follow the instructions at the link below:
+To import the update (`iot-middleware-sample-adu-v1.1.bin`) and manifest (`Contoso.STM32L475.1.1.importmanifest.json`), follow the instructions at the link below:
 
 - [Import Update and Manifest](https://docs.microsoft.com/azure/iot-hub-device-update/import-update)
 

--- a/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
@@ -515,7 +515,7 @@ static unsigned char root_cert_array[] = {
 
 #define democonfigADU_DEVICE_MANUFACTURER    "STMicroelectronics"
 #define democonfigADU_DEVICE_MODEL           "STM32L475"
-#define democonfigADU_UPDATE_PROVIDER        "STMicroelectronics"
+#define democonfigADU_UPDATE_PROVIDER        "Contoso"
 #define democonfigADU_UPDATE_NAME            "STM32L475"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
Update the ADU samples to use "Contoso" as the provider, making it clear the device information is being published by non-production samples.
Customers shall update the ADU device properties accordingly for their production projects.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the ADU samples (ESP32, STL475 and PC/Linux).

## What to Check
Verify the manifests generated through the update steps contain "Contoso" as the provider, and that the updates are still successful.

## Other Information
If your garbage collection provider offers recycling, make sure your recyclables are washed clean and put directly in the collection bin, [not bagged](https://residentialwastesystems.com/blog/should-i-put-my-recyclables-in-a-garbage-bag/).