### PR TITLE
Update to latest azure-iot-middleware-freertos, use USE_COREHTTP flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,4 +42,5 @@ set(FREERTOS_PORT_DIRECTORY ${BOARD_DEMO_FREERTOS_PORT_PATH} CACHE STRING "FreeR
 include_directories(${BOARD_DEMO_PORT_PATH})
 
 # Add middleware
+set(USE_COREHTTP ON)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/azure-iot-middleware-freertos)


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
A new cmake flag was introduced to azure-iot-middleware-freertos to only build az::iot_middleware::core_http (and require FreeRTOS' coreHTTP) if the customer opts in (with USE_COREHTTP=ON). This PR updates the samples repo to use the latest azure-iot-middleware-freertos lib and this new flag.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the samples as usual.

## What to Check
Verify that the samples build successfully. That indicates the CMakeLists.txt of the samples repo is setting USE_COREHTTP to ON correctly.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
In [Modern Family](https://en.wikipedia.org/wiki/Modern_Family), Alex Dunphy was portrayed as the genius kid and her brother Luke as not so smart. In reality, the actor that played Luke [Nolan Gould](https://en.wikipedia.org/wiki/Nolan_Gould) is a member of Mensa. 