### PR TITLE
Build adu dps payload

### DIFF
--- a/demos/projects/ESPRESSIF/adu/config/demo_config.h
+++ b/demos/projects/ESPRESSIF/adu/config/demo_config.h
@@ -43,7 +43,7 @@
  *        This plug-and-play model can be found at:
  *        https://github.com/Azure/iot-plugandplay-models/blob/main/dtmi/azureiot/devkit/freertos/esp32azureiotkit-1.json
  */
-#define sampleazureiotMODEL_ID                                "dtmi:azure:iot:deviceUpdateModel;1"
+#define sampleazureiotMODEL_ID                                "dtmi:com:example:Thermostat;1"
 
 
 /**

--- a/demos/projects/ESPRESSIF/adu/config/demo_config.h
+++ b/demos/projects/ESPRESSIF/adu/config/demo_config.h
@@ -39,14 +39,6 @@
 /************ End of logging configuration ****************/
 
 /**
- * @brief The model id for this device.
- *        This plug-and-play model can be found at:
- *        https://github.com/Azure/iot-plugandplay-models/blob/main/dtmi/azureiot/devkit/freertos/esp32azureiotkit-1.json
- */
-#define sampleazureiotMODEL_ID                                "dtmi:com:example:Thermostat;1"
-
-
-/**
  * @brief Enable Device Provisioning
  */
 

--- a/demos/projects/NXP/mimxrt1060/config/demo_config.h
+++ b/demos/projects/NXP/mimxrt1060/config/demo_config.h
@@ -13,7 +13,7 @@
  * This Model ID is tightly tied to the code implementation in `sample_azure_iot_pnp_simulated_device.c`
  * If you intend to test a different Model ID, please provide the implementation of the model on your application.
  */
-#define sampleazureiotMODEL_ID                                "dtmi:azure:iot:deviceUpdateModel;1"
+#define sampleazureiotMODEL_ID                                "dtmi:com:example:Thermostat;1"
 
 /**************************************************/
 /******* DO NOT CHANGE the following order ********/

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -974,15 +974,15 @@ static void prvAzureDemoTask( void * pvParameters )
             return xResult;
         }
         else if( ( xResult = AzureIoTJSONWriter_AppendPropertyName( &xWriter,
-                                                                ( uint8_t * ) sampleazureiotMODEL_ID_STR,
-                                                                sizeof( sampleazureiotMODEL_ID_STR ) - 1 ) ) != eAzureIoTSuccess )
+                                                                    ( uint8_t * ) sampleazureiotMODEL_ID_STR,
+                                                                    sizeof( sampleazureiotMODEL_ID_STR ) - 1 ) ) != eAzureIoTSuccess )
         {
             LogError( ( "Error appending property: result 0x%08x", xResult ) );
             return xResult;
         }
         else if( ( xResult = AzureIoTJSONWriter_AppendString( &xWriter,
-                                                                   AzureIoTADUModelID,
-                                                                   AzureIoTADUModelIDLength ) ) != eAzureIoTSuccess )
+                                                              AzureIoTADUModelID,
+                                                              AzureIoTADUModelIDLength ) ) != eAzureIoTSuccess )
         {
             LogError( ( "Error appending string: result 0x%08x", xResult ) );
             return xResult;

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -154,7 +154,6 @@ uint64_t ullGetUnixTime( void );
     static uint8_t ucSampleIotHubHostname[ 128 ];
     static uint8_t ucSampleIotHubDeviceId[ 128 ];
     static AzureIoTProvisioningClient_t xAzureIoTProvisioningClient;
-    static uint8_t ucProvisioningPayloadBuffer[ 128 ];
     #define sampleazureiotMODEL_ID_STR    "modelId"
 #endif /* democonfigENABLE_DPS_SAMPLE */
 
@@ -973,18 +972,13 @@ static void prvAzureDemoTask( void * pvParameters )
             LogError( ( "Error appending begin object: result 0x%08x", xResult ) );
             return xResult;
         }
-        else if( ( xResult = AzureIoTJSONWriter_AppendPropertyName( &xWriter,
-                                                                    ( uint8_t * ) sampleazureiotMODEL_ID_STR,
-                                                                    sizeof( sampleazureiotMODEL_ID_STR ) - 1 ) ) != eAzureIoTSuccess )
+        else if( ( xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter,
+                                                                               ( uint8_t * ) sampleazureiotMODEL_ID_STR,
+                                                                               sizeof( sampleazureiotMODEL_ID_STR ) - 1,
+                                                                               AzureIoTADUModelID,
+                                                                               AzureIoTADUModelIDLength ) ) != eAzureIoTSuccess )
         {
-            LogError( ( "Error appending property: result 0x%08x", xResult ) );
-            return xResult;
-        }
-        else if( ( xResult = AzureIoTJSONWriter_AppendString( &xWriter,
-                                                              AzureIoTADUModelID,
-                                                              AzureIoTADUModelIDLength ) ) != eAzureIoTSuccess )
-        {
-            LogError( ( "Error appending string: result 0x%08x", xResult ) );
+            LogError( ( "Error appending property name and string value: result 0x%08x", xResult ) );
             return xResult;
         }
         else if( ( xResult = AzureIoTJSONWriter_AppendEndObject( &xWriter ) ) != eAzureIoTSuccess )
@@ -1049,13 +1043,13 @@ static void prvAzureDemoTask( void * pvParameters )
             configASSERT( xResult == eAzureIoTSuccess );
         #endif /* democonfigDEVICE_SYMMETRIC_KEY */
 
-        xResult = prvCreateProvisioningPayload( ucProvisioningPayloadBuffer,
-                                                sizeof( ucProvisioningPayloadBuffer ),
+        xResult = prvCreateProvisioningPayload( ucScratchBuffer,
+                                                sizeof( ucScratchBuffer ),
                                                 &ulOutProvisioningPayloadLength );
         configASSERT( xResult == eAzureIoTSuccess );
 
         xResult = AzureIoTProvisioningClient_SetRegistrationPayload( &xAzureIoTProvisioningClient,
-                                                                     ( const uint8_t * ) ucProvisioningPayloadBuffer,
+                                                                     ( const uint8_t * ) ucScratchBuffer,
                                                                      ulOutProvisioningPayloadLength );
         configASSERT( xResult == eAzureIoTSuccess );
 

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -955,7 +955,7 @@ static void prvAzureDemoTask( void * pvParameters )
 
     static AzureIoTResult_t prvCreateProvisioningPayload( uint8_t * pucBuffer,
                                                           uint32_t ulBufferLength,
-                                                          uint32_t * pulOutBufferLength )
+                                                          int32_t * plOutBufferLength )
     {
         AzureIoTResult_t xResult;
         AzureIoTJSONWriter_t xWriter;
@@ -987,7 +987,7 @@ static void prvAzureDemoTask( void * pvParameters )
             return xResult;
         }
 
-        *pulOutBufferLength = AzureIoTJSONWriter_GetBytesUsed( &xWriter );
+        *plOutBufferLength = AzureIoTJSONWriter_GetBytesUsed( &xWriter );
 
         return xResult;
     }
@@ -1006,7 +1006,7 @@ static void prvAzureDemoTask( void * pvParameters )
         TlsTransportParams_t xTlsTransportParams = { 0 };
         AzureIoTResult_t xResult;
         AzureIoTTransportInterface_t xTransport;
-        uint32_t ulOutProvisioningPayloadLength;
+        int32_t lOutProvisioningPayloadLength;
         uint32_t ucSamplepIothubHostnameLength = sizeof( ucSampleIotHubHostname );
         uint32_t ucSamplepIothubDeviceIdLength = sizeof( ucSampleIotHubDeviceId );
         uint32_t ulStatus;
@@ -1045,12 +1045,12 @@ static void prvAzureDemoTask( void * pvParameters )
 
         xResult = prvCreateProvisioningPayload( ucScratchBuffer,
                                                 sizeof( ucScratchBuffer ),
-                                                &ulOutProvisioningPayloadLength );
+                                                &lOutProvisioningPayloadLength );
         configASSERT( xResult == eAzureIoTSuccess );
 
         xResult = AzureIoTProvisioningClient_SetRegistrationPayload( &xAzureIoTProvisioningClient,
                                                                      ( const uint8_t * ) ucScratchBuffer,
-                                                                     ulOutProvisioningPayloadLength );
+                                                                     ( uint32_t ) lOutProvisioningPayloadLength );
         configASSERT( xResult == eAzureIoTSuccess );
 
         do

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -154,6 +154,8 @@ uint64_t ullGetUnixTime( void );
     static uint8_t ucSampleIotHubHostname[ 128 ];
     static uint8_t ucSampleIotHubDeviceId[ 128 ];
     static AzureIoTProvisioningClient_t xAzureIoTProvisioningClient;
+    static uint8_t ucProvisioningPayloadBuffer[ 60 ];
+    #define sampleazureiotMODEL_ID_STR    "modelId"
 #endif /* democonfigENABLE_DPS_SAMPLE */
 
 /* Each compilation unit must define the NetworkContext struct. */
@@ -950,6 +952,48 @@ static void prvAzureDemoTask( void * pvParameters )
 
 #ifdef democonfigENABLE_DPS_SAMPLE
 
+/*-----------------------------------------------------------*/
+
+    static AzureIoTResult_t prvCreateProvisioningPayload( uint8_t * pucBuffer,
+                                                          uint32_t ulBufferLength,
+                                                          uint32_t * pulOutBufferLength )
+    {
+        AzureIoTResult_t xResult;
+        AzureIoTJSONWriter_t xWriter;
+
+        if( ( xResult = AzureIoTJSONWriter_Init( &xWriter, pucBuffer, ulBufferLength ) ) != eAzureIoTSuccess )
+        {
+            LogError( ( "Error initializing JSON writer: result 0x%08x", xResult ) );
+            return xResult;
+        }
+
+        if( ( xResult = AzureIoTJSONWriter_AppendBeginObject( &xWriter ) ) != eAzureIoTSuccess )
+        {
+            LogError( ( "Error appending begin object: result 0x%08x", xResult ) );
+            return xResult;
+        }
+
+        if( ( xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter,
+                                                                          ( uint8_t * ) sampleazureiotMODEL_ID_STR,
+                                                                          sizeof( sampleazureiotMODEL_ID_STR ) - 1,
+                                                                          AzureIoTADUModelID,
+                                                                          AzureIoTADUModelIDLength ) ) != eAzureIoTSuccess )
+        {
+            LogError( ( "Error appending property and string: result 0x%08x", xResult ) );
+            return xResult;
+        }
+
+        if( ( xResult = AzureIoTJSONWriter_AppendEndObject( &xWriter ) ) != eAzureIoTSuccess )
+        {
+            LogError( ( "Error appending end object: result 0x%08x", xResult ) );
+            return xResult;
+        }
+
+        *pulOutBufferLength = AzureIoTJSONWriter_GetBytesUsed( &xWriter );
+
+        return xResult;
+    }
+
 /**
  * @brief Get IoT Hub endpoint and device Id info, when Provisioning service is used.
  *   This function will block for Provisioning service for result or return failure.
@@ -964,6 +1008,7 @@ static void prvAzureDemoTask( void * pvParameters )
         TlsTransportParams_t xTlsTransportParams = { 0 };
         AzureIoTResult_t xResult;
         AzureIoTTransportInterface_t xTransport;
+        uint32_t ulOutProvisioningPayloadLength;
         uint32_t ucSamplepIothubHostnameLength = sizeof( ucSampleIotHubHostname );
         uint32_t ucSamplepIothubDeviceIdLength = sizeof( ucSampleIotHubDeviceId );
         uint32_t ulStatus;
@@ -1000,9 +1045,11 @@ static void prvAzureDemoTask( void * pvParameters )
             configASSERT( xResult == eAzureIoTSuccess );
         #endif /* democonfigDEVICE_SYMMETRIC_KEY */
 
+        prvCreateProvisioningPayload( ucProvisioningPayloadBuffer, sizeof( ucProvisioningPayloadBuffer ), &ulOutProvisioningPayloadLength );
+
         xResult = AzureIoTProvisioningClient_SetRegistrationPayload( &xAzureIoTProvisioningClient,
-                                                                     ( const uint8_t * ) sampleazureiotPROVISIONING_PAYLOAD,
-                                                                     sizeof( sampleazureiotPROVISIONING_PAYLOAD ) - 1 );
+                                                                     ( const uint8_t * ) ucProvisioningPayloadBuffer,
+                                                                     ulOutProvisioningPayloadLength );
         configASSERT( xResult == eAzureIoTSuccess );
 
         do

--- a/demos/sample_azure_iot_adu/sample_azure_iot_pnp_data_if.h
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_pnp_data_if.h
@@ -17,11 +17,6 @@
 #include "azure_iot_hub_client_properties.h"
 #include "demo_config.h"
 
-/**
- * @brief The payload to send to the Device Provisioning Service (DO NOT MODIFY)
- */
-#define sampleazureiotPROVISIONING_PAYLOAD    "{\"modelId\":\"" sampleazureiotMODEL_ID "\"}"
-
 extern AzureIoTHubClient_t xAzureIoTHubClient;
 extern AzureIoTADUClient_t xAzureIoTADUClient;
 extern AzureIoTADUUpdateRequest_t xAzureIoTAduUpdateRequest;


### PR DESCRIPTION
- The payload before was using the demo config model id which is the wrong one. This generates the DPS payload with the value which is given from the SDK.