### PR TITLE
add logs for linux sample

### DIFF
--- a/demos/projects/PC/linux/config/azure_iot_config.h
+++ b/demos/projects/PC/linux/config/azure_iot_config.h
@@ -40,6 +40,12 @@ extern void vLoggingPrintf( const char * pcFormatString,
     #define SdkLog( message )    vLoggingPrintf message
 #endif
 
+/* Middleware logging */
+#define AZLogError( message )    SdkLog( ( "[ERROR] [AZ IoT] [%s:%d]", __FILE__, __LINE__ ) ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+#define AZLogWarn( message )     SdkLog( ( "[WARN] [AZ IoT] ") ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+#define AZLogInfo( message )     SdkLog( ( "[INFO] [AZ IoT] ") ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+#define AZLogDebug( message )    SdkLog( ( "[DEBUG] [AZ IoT] ") ); SdkLog( message ); SdkLog( ( "\r\n" ) )
+
 #include "logging_stack.h"
 /************ End of logging configuration ****************/
 


### PR DESCRIPTION
- Logs were not being printed for the SDK for the Linux sample. This brings in line with other board samples.