### PR TITLE
use ppv dtmi

### DIFF
--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -134,6 +134,8 @@
  */
 #define ADU_HEADER_BUFFER_SIZE                                512
 
+#define democonfigADU_PPV_DTMI "dtmi:azure:iot:deviceUpdateContractModel;1"
+
 #define democonfigADU_UPDATE_ID                               "{\"provider\":\"" democonfigADU_UPDATE_PROVIDER "\",\"name\":\"" democonfigADU_UPDATE_NAME "\",\"version\":\"" democonfigADU_UPDATE_VERSION "\"}"
 
 #ifdef democonfigADU_UPDATE_NEW_VERSION
@@ -768,8 +770,8 @@ static void prvAzureDemoTask( void * pvParameters )
 
         xHubOptions.pucModuleID = ( const uint8_t * ) democonfigMODULE_ID;
         xHubOptions.ulModuleIDLength = sizeof( democonfigMODULE_ID ) - 1;
-        xHubOptions.pucModelID = ( const uint8_t * ) AzureIoTADUModelID;
-        xHubOptions.ulModelIDLength = AzureIoTADUModelIDLength;
+        xHubOptions.pucModelID = ( const uint8_t * ) democonfigADU_PPV_DTMI;
+        xHubOptions.ulModelIDLength = sizeof(democonfigADU_PPV_DTMI) - 1;
 
         #ifdef sampleaduPNP_COMPONENTS_LIST_LENGTH
             #if sampleaduPNP_COMPONENTS_LIST_LENGTH > 0

--- a/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
+++ b/demos/sample_azure_iot_adu/sample_azure_iot_adu.c
@@ -134,7 +134,7 @@
  */
 #define ADU_HEADER_BUFFER_SIZE                                512
 
-#define democonfigADU_PPV_DTMI "dtmi:azure:iot:deviceUpdateContractModel;1"
+#define democonfigADU_PPV_DTMI                                "dtmi:azure:iot:deviceUpdateContractModel;1"
 
 #define democonfigADU_UPDATE_ID                               "{\"provider\":\"" democonfigADU_UPDATE_PROVIDER "\",\"name\":\"" democonfigADU_UPDATE_NAME "\",\"version\":\"" democonfigADU_UPDATE_VERSION "\"}"
 
@@ -771,7 +771,7 @@ static void prvAzureDemoTask( void * pvParameters )
         xHubOptions.pucModuleID = ( const uint8_t * ) democonfigMODULE_ID;
         xHubOptions.ulModuleIDLength = sizeof( democonfigMODULE_ID ) - 1;
         xHubOptions.pucModelID = ( const uint8_t * ) democonfigADU_PPV_DTMI;
-        xHubOptions.ulModelIDLength = sizeof(democonfigADU_PPV_DTMI) - 1;
+        xHubOptions.ulModelIDLength = sizeof( democonfigADU_PPV_DTMI ) - 1;
 
         #ifdef sampleaduPNP_COMPONENTS_LIST_LENGTH
             #if sampleaduPNP_COMPONENTS_LIST_LENGTH > 0


### PR DESCRIPTION
Uses the `;1` version of the DTMI to be compatible with the `interfaceId` field of the device properties field.