### PR TITLE
Add recovery in iothub case as well

### DIFF
--- a/demos/projects/ESPRESSIF/az-ca-recovery/README.md
+++ b/demos/projects/ESPRESSIF/az-ca-recovery/README.md
@@ -466,3 +466,7 @@ I (6322) tls_freertos: (Network connection 0x3ffc8c4c) Connection to contoso-iot
 ...
 ```
 </details>
+
+## Troubleshooting
+
+- If you receive a message from DPS that the "Custom Allocation failed" with the return code of `400`, make sure you added the certificate thumbprint to the Azure Function ([see here for details](#create-and-import-signing-certificate)).

--- a/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
+++ b/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
@@ -349,19 +349,19 @@ static void runRecovery( NetworkCredentials_t * xNetworkCredentials,
     if( ( ulStatus = prvRunRecovery( xNetworkCredentials ) ) != 0 )
     {
         LogError( ( "Failed to run recovery error code = 0x%08x\r\n", ulStatus ) );
-        configASSERT( ulStatus == 0 );
+        configASSERT( false );
     }
     else if( ( ulStatus = prvSetupNetworkCredentials( xNetworkCredentials ) ) != 0 )
     {
         LogError( ( "Could not set network credentials\r\n" ) );
-        configASSERT( ulStatus == 0 );
+        configASSERT( false );
     }
     else if( ( ulStatus = prvIoTHubInfoGet( xNetworkCredentials, pucIotHubHostname,
                                             pulIothubHostnameLength, pucIotHubDeviceId,
                                             pulIothubDeviceIdLength ) ) != 0 )
     {
         LogError( ( "Failed to run DPS after recovery!: error code = 0x%08x\r\n", ulStatus ) );
-        configASSERT( ulStatus == 0 );
+        configASSERT( false );
     }
 }
 
@@ -453,7 +453,7 @@ static void prvAzureDemoTask( void * pvParameters )
             if( ulTLSStatus == eTLSTransportCAVerifyFailed )
             {
                 LogError( ( "Failed to connect to IoT Hub: Server verification failed after recovery attempt.\r\n" ) );
-                configASSERT( ulStatus == 0 );
+                configASSERT( false );
             }
         }
 

--- a/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
+++ b/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
@@ -605,8 +605,6 @@ static void prvAzureDemoTask( void * pvParameters )
 
         if( ulTLSStatus == eTLSTransportCAVerifyFailed )
         {
-            LogInfo( ( "In recovery\r\n" ) );
-
             return sampleazureiotRECOVERY_INITIATED;
         }
 

--- a/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
+++ b/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
@@ -334,6 +334,39 @@ static uint32_t prvSetupRecoveryNetworkCredentials( NetworkCredentials_t * pxNet
 }
 /*-----------------------------------------------------------*/
 
+static void runRecovery( NetworkCredentials_t * xNetworkCredentials,
+                         uint8_t ** pucIotHubHostname,
+                         uint8_t ** pucIotHubDeviceId,
+                         uint32_t * pulIothubHostnameLength,
+                         uint32_t * pulIothubDeviceIdLength )
+{
+    LogInfo( ( "In recovery\r\n" ) );
+
+    memset( &xNetworkCredentials, 0, sizeof( xNetworkCredentials ) );
+    ulStatus = prvSetupRecoveryNetworkCredentials( &xNetworkCredentials );
+    configASSERT( ulStatus == 0 );
+
+    if( ( ulStatus = prvRunRecovery( &xNetworkCredentials ) ) != 0 )
+    {
+        LogError( ( "Failed to run recovery error code = 0x%08x\r\n", ulStatus ) );
+        configASSERT( ulStatus == 0 );
+    }
+    else if( ( ulStatus = prvSetupNetworkCredentials( &xNetworkCredentials ) ) != 0 )
+    {
+        LogError( ( "Could not set network credentials\r\n" ) );
+        configASSERT( ulStatus == 0 );
+    }
+    else if( ( ulStatus = prvIoTHubInfoGet( xNetworkCredentials, pucIotHubHostname,
+                                            pulIothubHostnameLength, pucIotHubDeviceId,
+                                            pulIothubDeviceIdLength ) ) != 0 )
+    {
+        LogError( ( "Failed to run DPS after recovery!: error code = 0x%08x\r\n", ulStatus ) );
+        configASSERT( ulStatus == 0 );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Azure IoT demo task that gets started in the platform specific project.
  *  In this demo task, middleware API's are used to connect to Azure IoT Hub.
@@ -381,27 +414,9 @@ static void prvAzureDemoTask( void * pvParameters )
         {
             if( ulStatus == sampleazureiotRECOVERY_INITIATED )
             {
-                memset( &xNetworkCredentials, 0, sizeof( xNetworkCredentials ) );
-                ulStatus = prvSetupRecoveryNetworkCredentials( &xNetworkCredentials );
-                configASSERT( ulStatus == 0 );
-
-                if( ( ulStatus = prvRunRecovery( &xNetworkCredentials ) ) != 0 )
-                {
-                    LogError( ( "Failed to run recovery error code = 0x%08x\r\n", ulStatus ) );
-                    configASSERT( ulStatus == 0 );
-                }
-                else if( ( ulStatus = prvSetupNetworkCredentials( &xNetworkCredentials ) ) != 0 )
-                {
-                    LogError( ( "Could not set network credentials\r\n" ) );
-                    configASSERT( ulStatus == 0 );
-                }
-                else if( ( ulStatus = prvIoTHubInfoGet( &xNetworkCredentials, &pucIotHubHostname,
-                                                        &pulIothubHostnameLength, &pucIotHubDeviceId,
-                                                        &pulIothubDeviceIdLength ) ) != 0 )
-                {
-                    LogError( ( "Failed to run DPS after recovery!: error code = 0x%08x\r\n", ulStatus ) );
-                    configASSERT( ulStatus == 0 );
-                }
+                runRecovery( &xNetworkCredentials, &pucIotHubHostname,
+                             &pulIothubHostnameLength, &pucIotHubDeviceId,
+                             &pulIothubDeviceIdLength );
             }
             else
             {
@@ -424,6 +439,23 @@ static void prvAzureDemoTask( void * pvParameters )
         TlsTransportStatus_t ulTLSStatus = prvConnectToServerWithBackoffRetries( ( const char * ) pucIotHubHostname,
                                                                                  democonfigIOTHUB_PORT,
                                                                                  &xNetworkCredentials, &xNetworkContext );
+
+        if( ulTLSStatus == eTLSTransportCAVerifyFailed )
+        {
+            runRecovery( &xNetworkCredentials, &pucIotHubHostname,
+                         &pulIothubHostnameLength, &pucIotHubDeviceId,
+                         &pulIothubDeviceIdLength );
+
+            TlsTransportStatus_t ulTLSStatus = prvConnectToServerWithBackoffRetries( ( const char * ) pucIotHubHostname,
+                                                                                     democonfigIOTHUB_PORT,
+                                                                                     &xNetworkCredentials, &xNetworkContext );
+
+            if( ulTLSStatus == eTLSTransportCAVerifyFailed )
+            {
+                LogError( ( "Failed to connect to IoT Hub: Server verification failed after recovery attempt.\r\n" ) );
+                configASSERT( ulStatus == 0 );
+            }
+        }
 
         /* Fill in Transport Interface send and receive function pointers. */
         xTransport.pxNetworkContext = &xNetworkContext;

--- a/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
+++ b/demos/sample_azure_iot_ca_recovery/sample_azure_iot_ca_recovery.c
@@ -336,22 +336,22 @@ static uint32_t prvSetupRecoveryNetworkCredentials( NetworkCredentials_t * pxNet
 
 static void runRecovery( NetworkCredentials_t * xNetworkCredentials,
                          uint8_t ** pucIotHubHostname,
-                         uint8_t ** pucIotHubDeviceId,
                          uint32_t * pulIothubHostnameLength,
+                         uint8_t ** pucIotHubDeviceId,
                          uint32_t * pulIothubDeviceIdLength )
 {
     LogInfo( ( "In recovery\r\n" ) );
 
-    memset( &xNetworkCredentials, 0, sizeof( xNetworkCredentials ) );
-    ulStatus = prvSetupRecoveryNetworkCredentials( &xNetworkCredentials );
+    memset( xNetworkCredentials, 0, sizeof( *xNetworkCredentials ) );
+    uint32_t ulStatus = prvSetupRecoveryNetworkCredentials( xNetworkCredentials );
     configASSERT( ulStatus == 0 );
 
-    if( ( ulStatus = prvRunRecovery( &xNetworkCredentials ) ) != 0 )
+    if( ( ulStatus = prvRunRecovery( xNetworkCredentials ) ) != 0 )
     {
         LogError( ( "Failed to run recovery error code = 0x%08x\r\n", ulStatus ) );
         configASSERT( ulStatus == 0 );
     }
-    else if( ( ulStatus = prvSetupNetworkCredentials( &xNetworkCredentials ) ) != 0 )
+    else if( ( ulStatus = prvSetupNetworkCredentials( xNetworkCredentials ) ) != 0 )
     {
         LogError( ( "Could not set network credentials\r\n" ) );
         configASSERT( ulStatus == 0 );


### PR DESCRIPTION
Two scenarios tested:

## Scenario 1

Original. DPS and Hub both on Baltimore. Device has certs which don't include Baltimore. Failed connection to `[OPERATIONAL]` DPS, connect to recovery, then get trust bundle, etc. Works ✅.

## Scenario 2 (new)

DPS on Baltimore and Hub migrated to Digicert. Device has Baltimore. Device succeeds to `[OPERATIONAL]` DPS, but fails to `[OPERATIONAL]` Hub. Fall back to `[RECOVERY]` DPS to get trust bundle, etc. Then reprovision and connect to `[OPERATIONAL]` hub. Works ✅.