### PR TITLE
Fix Windows sample for Release Builds

### DIFF
--- a/.github/scripts/ci_tests_windows.ps1
+++ b/.github/scripts/ci_tests_windows.ps1
@@ -33,7 +33,9 @@ function sample_build
         [string] $board,
         [Parameter(Mandatory=$true, Position=2)]
         [string] $outdir,
-        [Parameter(Mandatory=$false, Position=3)]
+        [Parameter(Mandatory=$true, Position=3)]
+        [string] $buildType,
+        [Parameter(Mandatory=$false, Position=4)]
         [string] $additionalFlags
     )
 
@@ -41,9 +43,9 @@ function sample_build
     git clean -xdf
 
     Write-Output "::group::CMake Config & Generate"
-    cmake -G "Visual Studio 17 2022" -A Win32 -DBOARD="$board" -DVENDOR="$vendor" -B"$outdir" -DFREERTOS_PATH="$test_freertos_src" "$additionalFlags" .
+    cmake -G "Visual Studio 17 2022" -A Win32 -DBOARD="$board" -DVENDOR="$vendor" -DCMAKE_BUILD_TYPE="$buildType" -B"$outdir" -DFREERTOS_PATH="$test_freertos_src" "$additionalFlags" .
     Write-Output "::group::CMake Build"
-    cmake --build "$outdir"
+    cmake --build "$outdir" --config "$buildType"
 }
 
 # FreeRTOS recursive download needs support for long path
@@ -51,7 +53,14 @@ git config --system core.longpaths true
 $freertos_fetch_script=Join-Path $PSScriptRoot "fetch_freertos.ps1"
 & "$freertos_fetch_script" -FREERTOS_SRC $test_freertos_src
 
-Write-Output "::group::Building sample for PC windows port"
-sample_build -vendor "PC" -board "windows" -outdir "build_windows" -additionalFlags "-DCMAKE_GENERATOR_PLATFORM=Win32"
-exit_if_binary_does_not_exist -search_dir "build_windows" -filename "iot-middleware-sample.exe"
-exit_if_binary_does_not_exist -search_dir "build_windows" -filename "iot-middleware-sample-pnp.exe"
+Write-Output "::group::Building sample for PC windows port - Release"
+sample_build -vendor "PC" -board "windows" -outdir "build_windows" -buildType "Release" -additionalFlags "-DCMAKE_GENERATOR_PLATFORM=Win32"
+exit_if_binary_does_not_exist -search_dir "build_windows\demos\projects\PC\windows\Release" -filename "iot-middleware-sample.exe"
+exit_if_binary_does_not_exist -search_dir "build_windows\demos\projects\PC\windows\Release" -filename "iot-middleware-sample-pnp.exe"
+
+Remove-Item -Recurse -Force build_windows
+
+Write-Output "::group::Building sample for PC windows port - Debug"
+sample_build -vendor "PC" -board "windows" -outdir "build_windows" -buildType "Debug" -additionalFlags "-DCMAKE_GENERATOR_PLATFORM=Win32"
+exit_if_binary_does_not_exist -search_dir "build_windows\demos\projects\PC\windows\Debug" -filename "iot-middleware-sample.exe"
+exit_if_binary_does_not_exist -search_dir "build_windows\demos\projects\PC\windows\Debug" -filename "iot-middleware-sample-pnp.exe"

--- a/.github/workflows/ci_tests_espidfv5.yml
+++ b/.github/workflows/ci_tests_espidfv5.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci_tests_linux.yml
+++ b/.github/workflows/ci_tests_linux.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ms_build.yml
+++ b/.github/workflows/ms_build.yml
@@ -5,15 +5,7 @@ on:
     branches:
       - main
   pull_request:
-
-env:
-  # Path to the solution file relative to the root of the project.
-  SOLUTION_FILE_PATH: .
-
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release
+  workflow_dispatch:
 
 jobs:
   build:

--- a/demos/projects/PC/windows/msvc_flags.cmake
+++ b/demos/projects/PC/windows/msvc_flags.cmake
@@ -7,7 +7,7 @@ set(MCU_C_FLAGS "/wd4127" /D_DEBUG
 add_compile_options(
       $<$<CONFIG:>:/MT> #---------|
       $<$<CONFIG:Debug>:/MTd> #---|-- Statically link the runtime libraries
-      $<$<CONFIG:Release>:/MT> #--|
+      $<$<CONFIG:Release>:/MD> #--|
       ${MCU_C_FLAGS})
 add_link_options(/NODEFAULTLIB:libcmtd.lib)
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Windows build would fail in release mode with `LNK2019 unresolved external symbol __except_handler4_common referenced in function __except_handler4 (MSVCRT.lib)` This is because the release build needs vcruntime.lib (https://stackoverflow.com/questions/31867018/unresolved-external-symbol-except-handler4-common-in-visual-studio-2015), which from this documentation (https://learn.microsoft.com/en-us/cpp/c-runtime-library/crt-library-features?view=msvc-170&viewFallbackFrom=vs-2019) shows that we need to use `/MD` instead of `/MT` in our `msvc_flags.cmake`
* This PR also adds building release in addition to debug in our pipeline
* This PR also adds the ability to manually trigger test runs on github.
    * How you'll be able to trigger: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
    * Docs on the change: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
build windows in both debug and release mode and make sure both work
Release:
```
cmake  -DVENDOR=PC -DCMAKE_GENERATOR_PLATFORM=Win32 -DCMAKE_BUILD_TYPE=Release -DBOARD=windows -Bbuild_windows .
cmake --build build_windows --config Release
```
Debug:
```
cmake  -DVENDOR=PC -DCMAKE_GENERATOR_PLATFORM=Win32 -DCMAKE_BUILD_TYPE=Debug -DBOARD=windows -Bbuild_windows .
cmake --build build_windows
```
## What to Check
Verify that the following are valid
* sample builds and runs as expected

## Other Information
<!-- Add any other helpful information that may be needed here. -->