### PR TITLE
Add a content-type and encoding properties on telemetry sent by ESP32

### DIFF
--- a/demos/sample_azure_iot/sample_azure_iot.c
+++ b/demos/sample_azure_iot/sample_azure_iot.c
@@ -424,14 +424,14 @@ static void prvAzureDemoTask( void * pvParameters )
 
         /* Sending a default property (Content-Type). */
         xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag,
-            ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE ) - 1,
-            ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_TYPE, sizeof( sampleazureiotMESSAGE_CONTENT_TYPE ) - 1 );
+                                                    ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE ) - 1,
+                                                    ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_TYPE, sizeof( sampleazureiotMESSAGE_CONTENT_TYPE ) - 1 );
         configASSERT( xResult == eAzureIoTSuccess );
 
         /* Sending a default property (Content-Encoding). */
         xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag,
-            ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING ) - 1,
-            ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_ENCODING, sizeof( sampleazureiotMESSAGE_CONTENT_ENCODING ) - 1 );
+                                                    ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING ) - 1,
+                                                    ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_ENCODING, sizeof( sampleazureiotMESSAGE_CONTENT_ENCODING ) - 1 );
         configASSERT( xResult == eAzureIoTSuccess );
 
         /* How to send an user-defined custom property. */

--- a/demos/sample_azure_iot/sample_azure_iot.c
+++ b/demos/sample_azure_iot/sample_azure_iot.c
@@ -82,7 +82,14 @@
  * @remark Message properties must be url-encoded.
  *         This message property is not required to send telemetry.
  */
-#define sampleazureiotMESSAGE_CONTENT_TYPE                    "text%2Fhtml%3B%20charset%3Dus-ascii"
+#define sampleazureiotMESSAGE_CONTENT_TYPE                    "text%2Fplain"
+
+/**
+ * @brief  The content encoding of the Telemetry message published in this example.
+ * @remark Message properties must be url-encoded.
+ *         This message property is not required to send telemetry.
+ */
+#define sampleazureiotMESSAGE_CONTENT_ENCODING                "us-ascii"
 
 /**
  * @brief The reported property payload to send to IoT Hub
@@ -140,7 +147,7 @@ uint64_t ullGetUnixTime( void );
     static AzureIoTProvisioningClient_t xAzureIoTProvisioningClient;
 #endif /* democonfigENABLE_DPS_SAMPLE */
 
-static uint8_t ucPropertyBuffer[ 64 ];
+static uint8_t ucPropertyBuffer[ 80 ];
 static uint8_t ucScratchBuffer[ 128 ];
 
 /* Each compilation unit must define the NetworkContext struct. */
@@ -419,6 +426,12 @@ static void prvAzureDemoTask( void * pvParameters )
         xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag,
             ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE ) - 1,
             ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_TYPE, sizeof( sampleazureiotMESSAGE_CONTENT_TYPE ) - 1 );
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        /* Sending a default property (Content-Encoding). */
+        xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag,
+            ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_ENCODING ) - 1,
+            ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_ENCODING, sizeof( sampleazureiotMESSAGE_CONTENT_ENCODING ) - 1 );
         configASSERT( xResult == eAzureIoTSuccess );
 
         /* How to send an user-defined custom property. */

--- a/demos/sample_azure_iot/sample_azure_iot.c
+++ b/demos/sample_azure_iot/sample_azure_iot.c
@@ -78,6 +78,13 @@
 #define sampleazureiotMESSAGE                                 "Hello World : %d !"
 
 /**
+ * @brief  The content type of the Telemetry message published in this example.
+ * @remark Message properties must be url-encoded.
+ *         This message property is not required to send telemetry.
+ */
+#define sampleazureiotMESSAGE_CONTENT_TYPE                    "text%2Fhtml%3B%20charset%3Dus-ascii"
+
+/**
  * @brief The reported property payload to send to IoT Hub
  */
 #define sampleazureiotPROPERTY                                "{ \"PropertyIterationForCurrentConnection\": \"%d\" }"
@@ -133,7 +140,7 @@ uint64_t ullGetUnixTime( void );
     static AzureIoTProvisioningClient_t xAzureIoTProvisioningClient;
 #endif /* democonfigENABLE_DPS_SAMPLE */
 
-static uint8_t ucPropertyBuffer[ 32 ];
+static uint8_t ucPropertyBuffer[ 64 ];
 static uint8_t ucScratchBuffer[ 128 ];
 
 /* Each compilation unit must define the NetworkContext struct. */
@@ -408,6 +415,13 @@ static void prvAzureDemoTask( void * pvParameters )
         xResult = AzureIoTMessage_PropertiesInit( &xPropertyBag, ucPropertyBuffer, 0, sizeof( ucPropertyBuffer ) );
         configASSERT( xResult == eAzureIoTSuccess );
 
+        /* Sending a default property (Content-Type). */
+        xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag,
+            ( uint8_t * ) AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE, sizeof( AZ_IOT_MESSAGE_PROPERTIES_CONTENT_TYPE ) - 1,
+            ( uint8_t * ) sampleazureiotMESSAGE_CONTENT_TYPE, sizeof( sampleazureiotMESSAGE_CONTENT_TYPE ) - 1 );
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        /* How to send an user-defined custom property. */
         xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag, ( uint8_t * ) "name", sizeof( "name" ) - 1,
                                                     ( uint8_t * ) "value", sizeof( "value" ) - 1 );
         configASSERT( xResult == eAzureIoTSuccess );


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
Add an example of how to set content-type and content-encoding for telemetry in ESP32 sample.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run the ESP32 sample as usual.

## What to Check
Verify that in IoT Hub the telemetry is received with properties:


## Other Information
Strawberries are not berries.