### PR TITLE
Removing hardcoded expiration time, adding SNTP to samples

### DIFF
--- a/cmake/FindLWIP.cmake
+++ b/cmake/FindLWIP.cmake
@@ -9,7 +9,8 @@ if(NOT (TARGET LWIP))
     file(GLOB LWIP_PATH_SOURCES ${LWIP_PATH}/src/api/*.c
             ${LWIP_PATH}/src/core/ipv4/*.c
             ${LWIP_PATH}/src/core/*.c
-            ${LWIP_PATH}/src/netif/*.c)
+            ${LWIP_PATH}/src/netif/*.c
+            ${LWIP_PATH}/src/apps/sntp/*.c)
 
     target_sources(LWIP INTERFACE ${LWIP_PATH_SOURCES})
     target_include_directories(LWIP INTERFACE

--- a/demos/projects/NXP/mimxrt1060/CMakeLists.txt
+++ b/demos/projects/NXP/mimxrt1060/CMakeLists.txt
@@ -99,6 +99,8 @@ include(driver_phy-common)
 
 include(driver_dcp)
 
+include(driver_snvs_hp)
+
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
 target_link_libraries(${PROJECT_NAME} PRIVATE
     FreeRTOS::Timers

--- a/demos/projects/NXP/mimxrt1060/config/demo_config.h
+++ b/demos/projects/NXP/mimxrt1060/config/demo_config.h
@@ -240,7 +240,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "MIMXRT1060"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
-#define democonfigSNTP_INIT_WAIT             1672531200U // January 1, 2023
+#define democonfigSNTP_INIT_WAIT             1672531200U /* January 1, 2023 */
 #define democonfigSNTP_INIT_RETRY_DELAY      5000
 
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/NXP/mimxrt1060/config/demo_config.h
+++ b/demos/projects/NXP/mimxrt1060/config/demo_config.h
@@ -240,4 +240,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "MIMXRT1060"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
+#define democonfigSNTP_INIT_WAIT             1672531200U // January 1, 2023
+#define democonfigSNTP_INIT_RETRY_DELAY      5000
+
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/NXP/mimxrt1060/config/lwipopts.h
+++ b/demos/projects/NXP/mimxrt1060/config/lwipopts.h
@@ -341,6 +341,15 @@ void sys_mark_tcpip_thread( void );
 /* Define random number generator function */
 #define LWIP_RAND()    ( ( u32_t ) rand() )
 
+/* SNTP definitions */
+#define LWIP_SNTP 1
+#define SNTP_SUPPORT 1
+#define SNTP_SERVER_DNS 1
+#define SNTP_UPDATE_DELAY 86400
+
+extern void setTimeRTC( uint32_t sec );
+#define SNTP_SET_SYSTEM_TIME( sec ) setTimeRTC( sec )
+
 /* Debug */
 
 /*#define LWIP_DEBUG 1

--- a/demos/projects/NXP/mimxrt1060/config/lwipopts.h
+++ b/demos/projects/NXP/mimxrt1060/config/lwipopts.h
@@ -342,13 +342,13 @@ void sys_mark_tcpip_thread( void );
 #define LWIP_RAND()    ( ( u32_t ) rand() )
 
 /* SNTP definitions */
-#define LWIP_SNTP 1
-#define SNTP_SUPPORT 1
-#define SNTP_SERVER_DNS 1
-#define SNTP_UPDATE_DELAY 86400
+#define LWIP_SNTP            1
+#define SNTP_SUPPORT         1
+#define SNTP_SERVER_DNS      1
+#define SNTP_UPDATE_DELAY    86400
 
 extern void setTimeRTC( uint32_t sec );
-#define SNTP_SET_SYSTEM_TIME( sec ) setTimeRTC( sec )
+#define SNTP_SET_SYSTEM_TIME( sec )    setTimeRTC( sec )
 
 /* Debug */
 

--- a/demos/projects/NXP/mimxrt1060/main.c
+++ b/demos/projects/NXP/mimxrt1060/main.c
@@ -550,7 +550,6 @@ static void prvInitializeSNTP( void )
     
     configPRINTF( ("> SNTP Initialized: %lu\r\n",
                 unixTime) );
-    
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/projects/NXP/mimxrt1060/main.c
+++ b/demos/projects/NXP/mimxrt1060/main.c
@@ -92,7 +92,7 @@
     #define mainNETIF_INIT_FN    ethernetif0_init
 #endif /* mainNETIF_INIT_FN */
 
-#define NTP_EPOCH           ( 1900 )
+#define NTP_EPOCH                ( 1900 )
 
 /*******************************************************************************
  * Variables
@@ -105,8 +105,8 @@ static ethernetif_config_t xEnetConfig =
     .phyHandle  = &xPhyHandle,
     .macAddress = mainConfigMAC_ADDR,
 };
-static const char *pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
-const size_t numTimeServers = sizeof( pTimeServers ) / sizeof ( char * );
+static const char * pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
+const size_t numTimeServers = sizeof( pTimeServers ) / sizeof( char * );
 
 /*
  * Prototypes for the demos that can be started from this project.
@@ -127,17 +127,17 @@ static void prvInitializeRTC( void );
 
 /**
  * @brief Sets Real Time Clock
- * 
+ *
  * @param[in] sec Unsigned integer to set to
  */
 void setTimeRTC( uint32_t sec );
 
 /**
  * @brief Gets unix time from Real Time Clock
- * 
+ *
  * @param[out] pTime Pointer variable to store time in.
  */
-static void getTimeRTC( uint32_t* pTime );
+static void getTimeRTC( uint32_t * pTime );
 
 /*******************************************************************************
  * Code
@@ -528,34 +528,36 @@ static void prvInitializeSNTP( void )
 {
     uint32_t unixTime = 0;
 
-    configPRINTF( ("Initializing SNTP.\r\n") );
+    configPRINTF( ( "Initializing SNTP.\r\n" ) );
 
     sntp_setoperatingmode( SNTP_OPMODE_POLL );
-    for ( uint8_t i = 0; i < numTimeServers; i++ )
+
+    for( uint8_t i = 0; i < numTimeServers; i++ )
     {
         sntp_setservername( i, pTimeServers[ i ] );
     }
+
     sntp_init();
 
     do
     {
         getTimeRTC( &unixTime );
 
-        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        if( unixTime < democonfigSNTP_INIT_WAIT )
         {
-            configPRINTF( ("SNTP not queried yet. Retrying.\r\n") );
-            vTaskDelay ( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
+            configPRINTF( ( "SNTP not queried yet. Retrying.\r\n" ) );
+            vTaskDelay( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
         }
-    } while ( unixTime < democonfigSNTP_INIT_WAIT );
-    
-    configPRINTF( ("> SNTP Initialized: %lu\r\n",
-                unixTime) );
+    } while( unixTime < democonfigSNTP_INIT_WAIT );
+
+    configPRINTF( ( "> SNTP Initialized: %lu\r\n",
+                    unixTime ) );
 }
 /*-----------------------------------------------------------*/
 
 static void prvInitializeRTC( void )
 {
-    configPRINTF( ("Initializing RTC.\r\n") );
+    configPRINTF( ( "Initializing RTC.\r\n" ) );
 
     snvs_hp_rtc_config_t snvsRtcConfig;
     snvs_hp_rtc_datetime_t sInitDateTime;
@@ -563,7 +565,7 @@ static void prvInitializeRTC( void )
     SNVS_HP_RTC_GetDefaultConfig( &snvsRtcConfig );
     SNVS_HP_RTC_Init( SNVS, &snvsRtcConfig );
 
-    // Unix epoch
+    /* Unix epoch */
     sInitDateTime.year = 1970U;
     sInitDateTime.month = 1U;
     sInitDateTime.day = 1U;
@@ -574,7 +576,7 @@ static void prvInitializeRTC( void )
     SNVS_HP_RTC_SetDatetime( SNVS, &sInitDateTime );
     SNVS_HP_RTC_StartTimer( SNVS );
 
-    configPRINTF( ("> RTC Initialized.\r\n") );
+    configPRINTF( ( "> RTC Initialized.\r\n" ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -585,19 +587,19 @@ void setTimeRTC( uint32_t sec )
     snvs_hp_rtc_datetime_t sDateTime;
 
     gmtime_r( &unixTime, &calTime );
-    
+
     sDateTime.second = calTime.tm_sec;
     sDateTime.minute = calTime.tm_min;
     sDateTime.hour = calTime.tm_hour;
     sDateTime.day = calTime.tm_mday;
-    sDateTime.month = calTime.tm_mon + 1; // Account for different month range.
+    sDateTime.month = calTime.tm_mon + 1; /* Account for different month range. */
     sDateTime.year = calTime.tm_year + NTP_EPOCH;
 
     SNVS_HP_RTC_SetDatetime( SNVS, &sDateTime );
 }
 /*-----------------------------------------------------------*/
 
-static void getTimeRTC( uint32_t* pTime )
+static void getTimeRTC( uint32_t * pTime )
 {
     struct tm calTime;
     snvs_hp_rtc_datetime_t sDateTime;
@@ -608,7 +610,7 @@ static void getTimeRTC( uint32_t* pTime )
     calTime.tm_min = sDateTime.minute;
     calTime.tm_hour = sDateTime.hour;
     calTime.tm_mday = sDateTime.day;
-    calTime.tm_mon = sDateTime.month - 1; // Account for different month range.
+    calTime.tm_mon = sDateTime.month - 1; /* Account for different month range. */
     calTime.tm_year = sDateTime.year - NTP_EPOCH;
 
     *pTime = mktime( &calTime );
@@ -618,6 +620,7 @@ static void getTimeRTC( uint32_t* pTime )
 uint64_t ullGetUnixTime( void )
 {
     uint32_t unixTime;
+
     getTimeRTC( &unixTime );
     return ( uint64_t ) unixTime;
 }

--- a/demos/projects/NXP/mimxrt1060/main.c
+++ b/demos/projects/NXP/mimxrt1060/main.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <time.h>
 
 #include "board.h"
 
@@ -15,6 +16,7 @@
 #include <stdbool.h>
 
 #include "FreeRTOS.h"
+#include "demo_config.h"
 #include "task.h"
 
 #include "lwip/netifapi.h"
@@ -23,6 +25,7 @@
 #include "lwip/dhcp.h"
 #include "lwip/dns.h"
 #include "lwip/prot/dhcp.h"
+#include "lwip/apps/sntp.h"
 #include "netif/ethernet.h"
 #include "enet_ethernetif.h"
 #include "fsl_phy.h"
@@ -34,7 +37,7 @@
 #include "fsl_iomuxc.h"
 #include "fsl_phyksz8081.h"
 #include "fsl_enet_mdio.h"
-
+#include "fsl_snvs_hp.h"
 
 #include "fsl_common.h"
 
@@ -89,6 +92,8 @@
     #define mainNETIF_INIT_FN    ethernetif0_init
 #endif /* mainNETIF_INIT_FN */
 
+#define NTP_EPOCH           ( 1900 )
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
@@ -100,7 +105,8 @@ static ethernetif_config_t xEnetConfig =
     .phyHandle  = &xPhyHandle,
     .macAddress = mainConfigMAC_ADDR,
 };
-static uint64_t ulGlobalEntryTime = 1707465600;
+static const char *pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
+const size_t numTimeServers = sizeof( pTimeServers ) / sizeof ( char * );
 
 /*
  * Prototypes for the demos that can be started from this project.
@@ -108,6 +114,30 @@ static uint64_t ulGlobalEntryTime = 1707465600;
 extern void vStartDemoTask( void );
 
 static void prvNetworkUp( void );
+
+/**
+ * @brief Initializes LWIP SNTP.
+ */
+static void prvInitializeSNTP( void );
+
+/**
+ * @brief Initialize Real Time Clock
+ */
+static void prvInitializeRTC( void );
+
+/**
+ * @brief Sets Real Time Clock
+ * 
+ * @param[in] sec Unsigned integer to set to
+ */
+void setTimeRTC( uint32_t sec );
+
+/**
+ * @brief Gets unix time from Real Time Clock
+ * 
+ * @param[out] pTime Pointer variable to store time in.
+ */
+static void getTimeRTC( uint32_t* pTime );
 
 /*******************************************************************************
  * Code
@@ -259,6 +289,8 @@ int uxRand( void )
 void vApplicationDaemonTaskStartupHook( void )
 {
     prvNetworkUp();
+    prvInitializeRTC();
+    prvInitializeSNTP();
 
     /* Demos that use the network are created after the network is
      * up. */
@@ -492,22 +524,103 @@ void * pvPortCalloc( size_t xNum,
 }
 /*-----------------------------------------------------------*/
 
+static void prvInitializeSNTP( void )
+{
+    uint32_t unixTime = 0;
+
+    configPRINTF( ("Initializing SNTP.\r\n") );
+
+    sntp_setoperatingmode( SNTP_OPMODE_POLL );
+    for ( uint8_t i = 0; i < numTimeServers; i++ )
+    {
+        sntp_setservername( i, pTimeServers[ i ] );
+    }
+    sntp_init();
+
+    do
+    {
+        getTimeRTC( &unixTime );
+
+        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        {
+            configPRINTF( ("SNTP not queried yet. Retrying.\r\n") );
+            vTaskDelay ( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
+        }
+    } while ( unixTime < democonfigSNTP_INIT_WAIT );
+    
+    configPRINTF( ("> SNTP Initialized: %lu\r\n",
+                unixTime) );
+    
+}
+/*-----------------------------------------------------------*/
+
+static void prvInitializeRTC( void )
+{
+    configPRINTF( ("Initializing RTC.\r\n") );
+
+    snvs_hp_rtc_config_t snvsRtcConfig;
+    snvs_hp_rtc_datetime_t sInitDateTime;
+
+    SNVS_HP_RTC_GetDefaultConfig( &snvsRtcConfig );
+    SNVS_HP_RTC_Init( SNVS, &snvsRtcConfig );
+
+    // Unix epoch
+    sInitDateTime.year = 1970U;
+    sInitDateTime.month = 1U;
+    sInitDateTime.day = 1U;
+    sInitDateTime.hour = 0U;
+    sInitDateTime.minute = 0U;
+    sInitDateTime.second = 0U;
+
+    SNVS_HP_RTC_SetDatetime( SNVS, &sInitDateTime );
+    SNVS_HP_RTC_StartTimer( SNVS );
+
+    configPRINTF( ("> RTC Initialized.\r\n") );
+}
+/*-----------------------------------------------------------*/
+
+void setTimeRTC( uint32_t sec )
+{
+    struct tm calTime;
+    time_t unixTime = sec;
+    snvs_hp_rtc_datetime_t sDateTime;
+
+    gmtime_r( &unixTime, &calTime );
+    
+    sDateTime.second = calTime.tm_sec;
+    sDateTime.minute = calTime.tm_min;
+    sDateTime.hour = calTime.tm_hour;
+    sDateTime.day = calTime.tm_mday;
+    sDateTime.month = calTime.tm_mon + 1; // Account for different month range.
+    sDateTime.year = calTime.tm_year + NTP_EPOCH;
+
+    SNVS_HP_RTC_SetDatetime( SNVS, &sDateTime );
+}
+/*-----------------------------------------------------------*/
+
+static void getTimeRTC( uint32_t* pTime )
+{
+    struct tm calTime;
+    snvs_hp_rtc_datetime_t sDateTime;
+
+    SNVS_HP_RTC_GetDatetime( SNVS, &sDateTime );
+
+    calTime.tm_sec = sDateTime.second;
+    calTime.tm_min = sDateTime.minute;
+    calTime.tm_hour = sDateTime.hour;
+    calTime.tm_mday = sDateTime.day;
+    calTime.tm_mon = sDateTime.month - 1; // Account for different month range.
+    calTime.tm_year = sDateTime.year - NTP_EPOCH;
+
+    *pTime = mktime( &calTime );
+}
+/*-----------------------------------------------------------*/
+
 uint64_t ullGetUnixTime( void )
 {
-    TickType_t xTickCount = 0;
-    uint64_t ulTime = 0UL;
-
-    /* Get the current tick count. */
-    xTickCount = xTaskGetTickCount();
-
-    /* Convert the ticks to milliseconds. */
-    ulTime = ( uint64_t ) xTickCount / configTICK_RATE_HZ;
-
-    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
-     * elapsed time in the application. */
-    ulTime = ( uint64_t ) ( ulTime + ulGlobalEntryTime );
-
-    return ulTime;
+    uint32_t unixTime;
+    getTimeRTC( &unixTime );
+    return ( uint64_t ) unixTime;
 }
 /*-----------------------------------------------------------*/
 

--- a/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
@@ -262,4 +262,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32L475"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
+#define democonfigSNTP_INIT_WAIT             1000000000
+#define democonfigSNTP_INIT_RETRY_DELAY      10000
+
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
@@ -262,7 +262,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32L475"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
-#define democonfigSNTP_INIT_WAIT             1000000000
-#define democonfigSNTP_INIT_RETRY_DELAY      10000
+#define democonfigSNTP_INIT_WAIT             1000000000U
+#define democonfigSNTP_INIT_RETRY_DELAY      5000
 
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/b-l475e-iot01a/main.c
+++ b/demos/projects/ST/b-l475e-iot01a/main.c
@@ -67,7 +67,6 @@ xSemaphoreHandle xWifiSemaphoreHandle;
 static UART_HandleTypeDef xConsoleUart;
 /* Use by the pseudo random number generator. */
 static UBaseType_t ulNextRand;
-static uint64_t ulGlobalEntryTime = 1707465600;
 
 /* Private function prototypes -----------------------------------------------*/
 static void Init_MEM1_Sensors( void );
@@ -102,6 +101,9 @@ static void prvInitializeHeap( void );
 /*-----------------------------------------------------------*/
 
 static BaseType_t prvInitializeWifi( void );
+/*-----------------------------------------------------------*/
+
+static BaseType_t prvInitializeSNTP( void );
 /*-----------------------------------------------------------*/
 
 void vLoggingPrintf( const char * pcFormat,
@@ -240,7 +242,39 @@ static BaseType_t prvInitializeWifi( void )
 
     return ret;
 }
+/*-----------------------------------------------------------*/
 
+static BaseType_t prvInitializeSNTP( void )
+{
+    BaseType_t ret = 0;
+    uint32_t unixTime = 0;
+
+    configPRINTF( ("ES-WIFI Initializing Time.\r\n") );
+
+    do
+    {
+        if ( WIFI_GetTime( &unixTime ) != WIFI_STATUS_OK )
+        {
+            configPRINTF( ("!!!ERROR: ES-WIFI Get Time Failed.\r\n") );
+            ret = -1;
+        }
+
+        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        {
+            configPRINTF( ("ES-WIFI Failed to get time. Retrying.\r\n") );
+            HAL_Delay ( democonfigSNTP_INIT_RETRY_DELAY );
+        }
+
+    } while ( ( unixTime < democonfigSNTP_INIT_WAIT ) && ( ret == 0 ) );
+
+    if ( ret == 0 )
+    {
+        configPRINTF( ("> ES-WIFI Time Initialized: %lu\r\n",
+                    unixTime) );
+    }
+
+    return ret;
+}
 /*-----------------------------------------------------------*/
 
 /* configUSE_STATIC_ALLOCATION is set to 1, so the application must provide an
@@ -365,6 +399,11 @@ static void prvMiscInitialization( void )
     Init_MEM1_Sensors();
 
     if( prvInitializeWifi() != 0 )
+    {
+        Error_Handler();
+    }
+
+    if( prvInitializeSNTP() != 0 )
     {
         Error_Handler();
     }
@@ -761,19 +800,10 @@ int mbedtls_platform_entropy_poll( void * data,
 
 uint64_t ullGetUnixTime( void )
 {
-    TickType_t xTickCount = 0;
-    uint64_t ulTime = 0UL;
+    uint32_t unixTime;
+    
+    WIFI_GetTime( &unixTime );
 
-    /* Get the current tick count. */
-    xTickCount = xTaskGetTickCount();
-
-    /* Convert the ticks to milliseconds. */
-    ulTime = ( uint64_t ) xTickCount / configTICK_RATE_HZ;
-
-    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
-     * elapsed time in the application. */
-    ulTime = ( uint64_t ) ( ulTime + ulGlobalEntryTime );
-
-    return ulTime;
+    return ( uint64_t ) unixTime;
 }
 /*-----------------------------------------------------------*/

--- a/demos/projects/ST/b-l475e-iot01a/main.c
+++ b/demos/projects/ST/b-l475e-iot01a/main.c
@@ -249,28 +249,27 @@ static BaseType_t prvInitializeSNTP( void )
     BaseType_t ret = 0;
     uint32_t unixTime = 0;
 
-    configPRINTF( ("ES-WIFI Initializing Time.\r\n") );
+    configPRINTF( ( "ES-WIFI Initializing Time.\r\n" ) );
 
     do
     {
-        if ( WIFI_GetTime( &unixTime ) != WIFI_STATUS_OK )
+        if( WIFI_GetTime( &unixTime ) != WIFI_STATUS_OK )
         {
-            configPRINTF( ("!!!ERROR: ES-WIFI Get Time Failed.\r\n") );
+            configPRINTF( ( "!!!ERROR: ES-WIFI Get Time Failed.\r\n" ) );
             ret = -1;
         }
 
-        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        if( unixTime < democonfigSNTP_INIT_WAIT )
         {
-            configPRINTF( ("ES-WIFI Failed to get time. Retrying.\r\n") );
-            HAL_Delay ( democonfigSNTP_INIT_RETRY_DELAY );
+            configPRINTF( ( "ES-WIFI Failed to get time. Retrying.\r\n" ) );
+            HAL_Delay( democonfigSNTP_INIT_RETRY_DELAY );
         }
+    } while( ( unixTime < democonfigSNTP_INIT_WAIT ) && ( ret == 0 ) );
 
-    } while ( ( unixTime < democonfigSNTP_INIT_WAIT ) && ( ret == 0 ) );
-
-    if ( ret == 0 )
+    if( ret == 0 )
     {
-        configPRINTF( ("> ES-WIFI Time Initialized: %lu\r\n",
-                    unixTime) );
+        configPRINTF( ( "> ES-WIFI Time Initialized: %lu\r\n",
+                        unixTime ) );
     }
 
     return ret;
@@ -801,7 +800,7 @@ int mbedtls_platform_entropy_poll( void * data,
 uint64_t ullGetUnixTime( void )
 {
     uint32_t unixTime;
-    
+
     WIFI_GetTime( &unixTime );
 
     return ( uint64_t ) unixTime;

--- a/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.c
+++ b/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.c
@@ -2534,4 +2534,32 @@ ES_WIFI_Status_t  ES_WIFI_StoreKey( ES_WIFIObject_t *Obj,
   UNLOCK_WIFI();
   return ret;
 }
+
+/**
+ * @brief Obtain time from clock
+ * 
+ * @param Obj: pointer to module handle
+ * @param pTime: pointer to variable to store time
+ * @return Operation Status.
+ */
+ES_WIFI_Status_t ES_WIFI_GetTime(   ES_WIFIObject_t *Obj,
+                                    uint32_t* pTime )
+{
+  ES_WIFI_Status_t ret = ES_WIFI_STATUS_ERROR;
+  LOCK_WIFI();
+
+  sprintf( ( char* )( Obj->CmdData ), "GT\r");
+
+  ret = AT_ExecuteCommand( Obj, Obj->CmdData, Obj->CmdData );
+  char* strTime = ( char* ) Obj->CmdData + 2;
+
+  if ( ret == ES_WIFI_STATUS_OK )
+  {
+    *pTime = strtoul( strTime, 0L, 10 );
+  }
+
+  UNLOCK_WIFI();
+  return ret;
+}
+
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.h
+++ b/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.h
@@ -55,6 +55,7 @@
 #include "string.h"
 #include "stdbool.h"
 #include "stdio.h"
+#include "stdlib.h"
 #include "es_wifi_conf.h"
 
 /* Exported Constants --------------------------------------------------------*/
@@ -363,6 +364,9 @@ ES_WIFI_Status_t  ES_WIFI_StoreKey( ES_WIFIObject_t *Obj,
                                     uint8_t credSet,
                                     uint8_t* key,
                                     uint16_t keyLength );
+
+ES_WIFI_Status_t ES_WIFI_GetTime(   ES_WIFIObject_t *Obj,
+                                    uint32_t* pTime );
 
 #ifdef __cplusplus
 }

--- a/demos/projects/ST/b-l475e-iot01a/st_code/wifi.c
+++ b/demos/projects/ST/b-l475e-iot01a/st_code/wifi.c
@@ -594,4 +594,22 @@ WIFI_Status_t WIFI_GetModuleName(char *ModuleName)
   }
   return ret;
 }
+
+/**
+ * @brief Return time from clock
+ * 
+ * @param pTime : Pointer to variable to store time in
+ * @return Operation status
+ */
+WIFI_Status_t WIFI_GetTime(uint32_t *pTime)
+{
+  WIFI_Status_t ret = WIFI_STATUS_ERROR;
+  
+  if (ES_WIFI_GetTime(&EsWifiObj, pTime) == ES_WIFI_STATUS_OK)
+  {
+    ret = WIFI_STATUS_OK;
+  }
+
+  return ret;
+}
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/demos/projects/ST/b-l475e-iot01a/st_code/wifi.h
+++ b/demos/projects/ST/b-l475e-iot01a/st_code/wifi.h
@@ -159,6 +159,9 @@ WIFI_Status_t       WIFI_ModuleFirmwareUpdate(const char *url);
 WIFI_Status_t       WIFI_GetModuleID(char *Id);
 WIFI_Status_t       WIFI_GetModuleFwRevision(char *rev);
 WIFI_Status_t       WIFI_GetModuleName(char *ModuleName);
+
+WIFI_Status_t       WIFI_GetTime(uint32_t *pTime);
+
 #ifdef __cplusplus
 }
 #endif

--- a/demos/projects/ST/b-l4s5i-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l4s5i-iot01a/config/demo_config.h
@@ -262,4 +262,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32L4S5I"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
+#define democonfigSNTP_INIT_WAIT             1000000000
+#define democonfigSNTP_INIT_RETRY_DELAY      10000
+
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/b-l4s5i-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l4s5i-iot01a/config/demo_config.h
@@ -262,7 +262,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32L4S5I"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
-#define democonfigSNTP_INIT_WAIT             1000000000
-#define democonfigSNTP_INIT_RETRY_DELAY      10000
+#define democonfigSNTP_INIT_WAIT             1000000000U
+#define democonfigSNTP_INIT_RETRY_DELAY      5000
 
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/stm32h745i-disco/cm7/config/demo_config.h
+++ b/demos/projects/ST/stm32h745i-disco/cm7/config/demo_config.h
@@ -239,4 +239,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32H745"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
+#define democonfigSNTP_INIT_WAIT             1672531200U // January 1, 2023
+#define democonfigSNTP_INIT_RETRY_DELAY      5000
+
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/stm32h745i-disco/cm7/config/demo_config.h
+++ b/demos/projects/ST/stm32h745i-disco/cm7/config/demo_config.h
@@ -239,7 +239,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigADU_UPDATE_NAME            "STM32H745"
 #define democonfigADU_UPDATE_VERSION         "1.0"
 
-#define democonfigSNTP_INIT_WAIT             1672531200U // January 1, 2023
+#define democonfigSNTP_INIT_WAIT             1672531200U /* January 1, 2023 */
 #define democonfigSNTP_INIT_RETRY_DELAY      5000
 
 #endif /* DEMO_CONFIG_H */

--- a/demos/projects/ST/stm32h745i-disco/cm7/main.c
+++ b/demos/projects/ST/stm32h745i-disco/cm7/main.c
@@ -23,8 +23,8 @@ void vApplicationDaemonTaskStartupHook( void );
 RNG_HandleTypeDef xHrng;
 RTC_HandleTypeDef xHrtc;
 UART_HandleTypeDef huart3;
-static const char *pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
-const size_t numTimeServers = sizeof( pTimeServers ) / sizeof ( char * );
+static const char * pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
+const size_t numTimeServers = sizeof( pTimeServers ) / sizeof( char * );
 
 /* Private function prototypes -----------------------------------------------*/
 static void SystemClock_Config( void );
@@ -51,17 +51,17 @@ static void prvInitializeRTC( void );
 
 /**
  * @brief Sets Real Time Clock
- * 
+ *
  * @param[in] sec Unsigned integer to set to
  */
 void setTimeRTC( uint32_t sec );
 
 /**
  * @brief Gets unix time from Real Time Clock
- * 
+ *
  * @param[out] pTime Pointer variable to store unix time in.
  */
-static void getTimeRTC( uint32_t* pTime );
+static void getTimeRTC( uint32_t * pTime );
 
 /*
  * Get board specific unix time.
@@ -669,29 +669,31 @@ int mbedtls_platform_entropy_poll( void * data,
 /*-----------------------------------------------------------*/
 
 static void prvInitializeSNTP( void )
-{   
+{
     uint32_t unixTime = 0;
 
     sntp_setoperatingmode( SNTP_OPMODE_POLL );
-    for ( uint8_t i = 0; i < numTimeServers; i++ )
+
+    for( uint8_t i = 0; i < numTimeServers; i++ )
     {
         sntp_setservername( i, pTimeServers[ i ] );
     }
+
     sntp_init();
 
     do
     {
         getTimeRTC( &unixTime );
 
-        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        if( unixTime < democonfigSNTP_INIT_WAIT )
         {
-            configPRINTF( ("SNTP not queried yet. Retrying.\r\n") );
-            vTaskDelay ( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
+            configPRINTF( ( "SNTP not queried yet. Retrying.\r\n" ) );
+            vTaskDelay( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
         }
-    } while ( unixTime < democonfigSNTP_INIT_WAIT );
-    
-    configPRINTF( ("> SNTP Initialized: %lu\r\n",
-                unixTime) );
+    } while( unixTime < democonfigSNTP_INIT_WAIT );
+
+    configPRINTF( ( "> SNTP Initialized: %lu\r\n",
+                    unixTime ) );
 }
 /*-----------------------------------------------------------*/
 
@@ -699,26 +701,26 @@ static void prvInitializeRTC( void )
 {
     xHrtc.Instance = RTC;
     xHrtc.Init.HourFormat = RTC_HOURFORMAT_24;
-    xHrtc.Init.AsynchPrediv   = 127;
-    xHrtc.Init.SynchPrediv    = 255;
-    xHrtc.Init.OutPut         = RTC_OUTPUT_DISABLE;
+    xHrtc.Init.AsynchPrediv = 127;
+    xHrtc.Init.SynchPrediv = 255;
+    xHrtc.Init.OutPut = RTC_OUTPUT_DISABLE;
     xHrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
-    xHrtc.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;
+    xHrtc.Init.OutPutType = RTC_OUTPUT_TYPE_OPENDRAIN;
 
-    if ( HAL_RTC_Init( &xHrtc ) != HAL_OK )
+    if( HAL_RTC_Init( &xHrtc ) != HAL_OK )
     {
         Error_Handler();
     }
 
-    setTimeRTC( 0 ); // Initializing at epoch.
+    setTimeRTC( 0 ); /* Initializing at epoch. */
 }
 /*-----------------------------------------------------------*/
 
-static void getTimeRTC( uint32_t* pTime )
+static void getTimeRTC( uint32_t * pTime )
 {
     struct tm calTime;
-    RTC_TimeTypeDef sTime = {0};
-    RTC_DateTypeDef sDate = {0};
+    RTC_TimeTypeDef sTime = { 0 };
+    RTC_DateTypeDef sDate = { 0 };
 
     HAL_RTC_GetTime( &xHrtc, &sTime, RTC_FORMAT_BIN );
     HAL_RTC_GetDate( &xHrtc, &sDate, RTC_FORMAT_BIN );
@@ -739,10 +741,10 @@ void setTimeRTC( uint32_t sec )
 {
     struct tm calTime;
     time_t unixTime = sec;
-    RTC_TimeTypeDef sTime = {0};
-    RTC_DateTypeDef sDate = {0};
+    RTC_TimeTypeDef sTime = { 0 };
+    RTC_DateTypeDef sDate = { 0 };
 
-    gmtime_r( &unixTime, &calTime ); 
+    gmtime_r( &unixTime, &calTime );
 
     sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     sTime.StoreOperation = RTC_STOREOPERATION_RESET;
@@ -765,6 +767,7 @@ void setTimeRTC( uint32_t sec )
 uint64_t ullGetUnixTime( void )
 {
     uint32_t unixTime;
+
     getTimeRTC( &unixTime );
     return ( uint64_t ) unixTime;
 }

--- a/demos/projects/ST/stm32h745i-disco/cm7/main.c
+++ b/demos/projects/ST/stm32h745i-disco/cm7/main.c
@@ -6,11 +6,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <time.h>
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
+#include "demo_config.h"
 #include "task.h"
 #include "lwip.h"
+#include "lwip/apps/sntp.h"
 
 /*-----------------------------------------------------------*/
 
@@ -20,6 +23,8 @@ void vApplicationDaemonTaskStartupHook( void );
 RNG_HandleTypeDef xHrng;
 RTC_HandleTypeDef xHrtc;
 UART_HandleTypeDef huart3;
+static const char *pTimeServers[] = { "pool.ntp.org", "time.nist.gov" };
+const size_t numTimeServers = sizeof( pTimeServers ) / sizeof ( char * );
 
 /* Private function prototypes -----------------------------------------------*/
 static void SystemClock_Config( void );
@@ -28,12 +33,35 @@ static void MPU_Config( void );
 static void MX_RNG_Init( void );
 static void MX_USART3_UART_Init( void );
 static char cPrintString[ 512 ];
-static uint64_t ulGlobalEntryTime = 1707465600;
 
 /*
  * Prototypes for the demos that can be started from this project.
  */
 extern void vStartDemoTask( void );
+
+/**
+ * @brief Initializes LWIP SNTP.
+ */
+static void prvInitializeSNTP( void );
+
+/**
+ * @brief Initialize Real Time Clock
+ */
+static void prvInitializeRTC( void );
+
+/**
+ * @brief Sets Real Time Clock
+ * 
+ * @param[in] sec Unsigned integer to set to
+ */
+void setTimeRTC( uint32_t sec );
+
+/**
+ * @brief Gets unix time from Real Time Clock
+ * 
+ * @param[out] pTime Pointer variable to store unix time in.
+ */
+static void getTimeRTC( uint32_t* pTime );
 
 /*
  * Get board specific unix time.
@@ -117,6 +145,8 @@ int uxRand( void )
 void vApplicationDaemonTaskStartupHook( void )
 {
     MX_LWIP_Init();
+    prvInitializeRTC();
+    prvInitializeSNTP();
 
     /* Demos that use the network are created after the network is
      * up. */
@@ -638,21 +668,104 @@ int mbedtls_platform_entropy_poll( void * data,
 }
 /*-----------------------------------------------------------*/
 
+static void prvInitializeSNTP( void )
+{   
+    uint32_t unixTime = 0;
+
+    sntp_setoperatingmode( SNTP_OPMODE_POLL );
+    for ( uint8_t i = 0; i < numTimeServers; i++ )
+    {
+        sntp_setservername( i, pTimeServers[ i ] );
+    }
+    sntp_init();
+
+    do
+    {
+        getTimeRTC( &unixTime );
+
+        if ( unixTime < democonfigSNTP_INIT_WAIT )
+        {
+            configPRINTF( ("SNTP not queried yet. Retrying.\r\n") );
+            vTaskDelay ( democonfigSNTP_INIT_RETRY_DELAY / portTICK_PERIOD_MS );
+        }
+    } while ( unixTime < democonfigSNTP_INIT_WAIT );
+    
+    configPRINTF( ("> SNTP Initialized: %lu\r\n",
+                unixTime) );
+}
+/*-----------------------------------------------------------*/
+
+static void prvInitializeRTC( void )
+{
+    xHrtc.Instance = RTC;
+    xHrtc.Init.HourFormat = RTC_HOURFORMAT_24;
+    xHrtc.Init.AsynchPrediv   = 127;
+    xHrtc.Init.SynchPrediv    = 255;
+    xHrtc.Init.OutPut         = RTC_OUTPUT_DISABLE;
+    xHrtc.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
+    xHrtc.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;
+
+    if ( HAL_RTC_Init( &xHrtc ) != HAL_OK )
+    {
+        Error_Handler();
+    }
+
+    setTimeRTC( 0 ); // Initializing at epoch.
+}
+/*-----------------------------------------------------------*/
+
+static void getTimeRTC( uint32_t* pTime )
+{
+    struct tm calTime;
+    RTC_TimeTypeDef sTime = {0};
+    RTC_DateTypeDef sDate = {0};
+
+    HAL_RTC_GetTime( &xHrtc, &sTime, RTC_FORMAT_BIN );
+    HAL_RTC_GetDate( &xHrtc, &sDate, RTC_FORMAT_BIN );
+
+    calTime.tm_sec = sTime.Seconds;
+    calTime.tm_min = sTime.Minutes;
+    calTime.tm_hour = sTime.Hours;
+    calTime.tm_isdst = sTime.DayLightSaving;
+    calTime.tm_mday = sDate.Date;
+    calTime.tm_mon = sDate.Month;
+    calTime.tm_year = sDate.Year;
+
+    *pTime = mktime( &calTime );
+}
+/*-----------------------------------------------------------*/
+
+void setTimeRTC( uint32_t sec )
+{
+    struct tm calTime;
+    time_t unixTime = sec;
+    RTC_TimeTypeDef sTime = {0};
+    RTC_DateTypeDef sDate = {0};
+
+    gmtime_r( &unixTime, &calTime ); 
+
+    sTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
+    sTime.StoreOperation = RTC_STOREOPERATION_RESET;
+    sTime.TimeFormat = RTC_HOURFORMAT_24;
+    sTime.Seconds = calTime.tm_sec;
+    sTime.SecondFraction = 0;
+    sTime.SubSeconds = 0;
+    sTime.Minutes = calTime.tm_min;
+    sTime.Hours = calTime.tm_hour;
+    sDate.WeekDay = calTime.tm_wday;
+    sDate.Date = calTime.tm_mday;
+    sDate.Month = calTime.tm_mon;
+    sDate.Year = calTime.tm_year;
+
+    HAL_RTC_SetTime( &xHrtc, &sTime, RTC_FORMAT_BIN );
+    HAL_RTC_SetDate( &xHrtc, &sDate, RTC_FORMAT_BIN );
+}
+/*-----------------------------------------------------------*/
+
 uint64_t ullGetUnixTime( void )
 {
-    TickType_t xTickCount = 0;
-    uint64_t ulTime = 0UL;
-
-    /* Get the current tick count. */
-    xTickCount = xTaskGetTickCount();
-
-    /* Convert the ticks to milliseconds. */
-    ulTime = ( uint64_t ) xTickCount / configTICK_RATE_HZ;
-
-    /* Reduce ulGlobalEntryTimeMs from obtained time so as to always return the
-     * elapsed time in the application. */
-    ulTime = ( uint64_t ) ( ulTime + ulGlobalEntryTime );
-
-    return ulTime;
+    uint32_t unixTime;
+    getTimeRTC( &unixTime );
+    return ( uint64_t ) unixTime;
 }
 /*-----------------------------------------------------------*/

--- a/demos/projects/ST/stm32h745i-disco/cm7/st_code/lwip/Target/lwipopts.h
+++ b/demos/projects/ST/stm32h745i-disco/cm7/st_code/lwip/Target/lwipopts.h
@@ -120,6 +120,16 @@
 #define LWIP_SO_SNDTIMEO 1
 //#define LWIP_TIMEVAL_PRIVATE (0)
 
+#define LWIP_UDP 1
+#define LWIP_SNTP 1
+#define SNTP_SUPPORT 1
+#define SNTP_SERVER_DNS 1
+#define SNTP_UPDATE_DELAY 86400
+#define MEMP_NUM_SYS_TIMEOUT 13
+
+extern void setTimeRTC( uint32_t sec );
+#define SNTP_SET_SYSTEM_TIME( sec ) setTimeRTC( sec ) 
+
  extern int uxRand();
  #define rand    uxRand
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Adding LWIP SNTP to H7, and MIMXRT1060.
* Enabling retrieval of timestamp from WIFI module for  L475, and L4S5 (wifi module does NTP automatically).
* Removes need for hardcoded timestamp.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Run the sample for any of the above mentioned boards. 

## What to Check
Verify that the following are valid
* Check the output of the board and ensure that SNTP is initialized with the correct time.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
Addressing issue #133 