### PR TITLE
Fixing potential DNS stack corruption for sockets_wrapper_lwip

### DIFF
--- a/demos/common/transport/sockets_wrapper_lwip.c
+++ b/demos/common/transport/sockets_wrapper_lwip.c
@@ -60,7 +60,7 @@ static void lwip_dns_found_callback( const char * ucName,
                                      const ip_addr_t * xIPAddr,
                                      void * pvCallbackArg )
 {
-    if (xDNSResolutionTaskHandle != NULL)
+    if( xDNSResolutionTaskHandle != NULL )
     {
         uint32_t * ulAddr = ( uint32_t * ) pvCallbackArg;
 
@@ -84,6 +84,7 @@ uint32_t prvGetHostByName( const char * pcHostName )
     err_t xLwipError = ERR_OK;
     ip_addr_t xLwipIpv4Address;
     uint32_t ulDNSNotificationValue = 0;
+
     xDNSResolutionTaskHandle = xTaskGetCurrentTaskHandle();
 
     if( strlen( pcHostName ) <= ( size_t ) SOCKETS_MAX_HOST_NAME_LENGTH )
@@ -107,8 +108,8 @@ uint32_t prvGetHostByName( const char * pcHostName )
                  */
                 ulDNSNotificationValue = ulTaskNotifyTake( pdTRUE, ( lwipdnsresolverMAX_WAIT_SECONDS * 1000 ) / portTICK_PERIOD_MS );
                 xDNSResolutionTaskHandle = NULL;
-                
-                if (ulDNSNotificationValue != 1 || ulAddr == 0)
+
+                if( ( ulDNSNotificationValue != 1 ) || ( ulAddr == 0 ) )
                 {
                     /* DNS resolution timed out */
                     configPRINTF( ( "Unable to resolve (%s) within (%lu) seconds",

--- a/demos/common/transport/sockets_wrapper_lwip.c
+++ b/demos/common/transport/sockets_wrapper_lwip.c
@@ -31,12 +31,6 @@
     #define lwipdnsresolverMAX_WAIT_SECONDS    ( 20 )
 #endif
 
-#define lwipdnsresolverLOOP_DELAY_MS           ( 250 )
-#define lwipdnsresolverLOOP_DELAY_TICKS        ( ( TickType_t ) lwipdnsresolverLOOP_DELAY_MS / portTICK_PERIOD_MS )
-#define lwipdnsresolverMAX_WAIT_CYCLES                 \
-    ( ( ( lwipdnsresolverMAX_WAIT_SECONDS ) * 1000 ) / \
-      ( lwipdnsresolverLOOP_DELAY_MS ) )
-
 /*
  * convert from system ticks to seconds.
  */


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Addressing #369 

DNS callback can be invoked after `prvGetHostByName` exits which sets memory for an inexistent variable. 

Solution is to wait for the task to complete using the Task Notification functionality of FreeRTOS.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Run our telemetry sample on the NXP1060 board or any board using `sockets_wrapper_lwip`. 

## What to Check
Check that it is able to send telemetry correctly.

## Other Information
<!-- Add any other helpful information that may be needed here. -->