### PR TITLE
Fix variable type warnings in b-l475e-iot01a/port/azure_iot_flash_platform.c

### DIFF
--- a/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
+++ b/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c
@@ -91,7 +91,7 @@ AzureIoTResult_t AzureIoTPlatform_WriteBlock( AzureADUImage_t * const pxAduImage
     uint8_t * pucNextWriteAddr = pxAduImage->xUpdatePartition + ulOffset;
     uint8_t * pucNextReadAddr = pData;
     AzureIoTResult_t xResult = eAzureIoTSuccess;
-    uint32_t ulEndOfBlock = pxAduImage->xUpdatePartition + ulOffset + ulBlockSize;
+    uint8_t * ulEndOfBlock = pxAduImage->xUpdatePartition + ulOffset + ulBlockSize;
 
     HAL_FLASH_Unlock();
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...

This fix addresses the following warnings:
C:/docs/iot-middleware-freertos-samples/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c:94:29: warning: initialization of 'uint32_t' {aka 'long unsigned int'} from 'uint8_t *' {aka 'unsigned char *'} makes integer from pointer without a cast [-Wint-conversion]
   94 |     uint32_t ulEndOfBlock = pxAduImage->xUpdatePartition + ulOffset + ulBlockSize;
      |                             ^~~~~~~~~~
C:/docs/iot-middleware-freertos-samples/demos/projects/ST/b-l475e-iot01a/port/azure_iot_flash_platform.c:98:29: warning: comparison between pointer and integer
   98 |     while( pucNextWriteAddr < ulEndOfBlock )
      |                             ^


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Test the sample ST b-l475e-iot01a.

## What to Check
That these specific warnings are not logged by the compiler.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
